### PR TITLE
Add health check based on a Meter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <!-- Need explicit Dropwizard version since dropwizard-util isn't defined in kiwi-bom 0.4.0 -->
         <dropwizard.version>2.0.28</dropwizard.version>
         <kiwi.version>1.2.0</kiwi.version>
+        <metrics-healthchecks-severity.version>1.0.2</metrics-healthchecks-severity.version>
 
         <!-- Versions for optional dependencies -->
 
@@ -81,6 +82,12 @@
             <groupId>org.kiwiproject</groupId>
             <artifactId>kiwi</artifactId>
             <version>${kiwi.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.kiwiproject</groupId>
+            <artifactId>metrics-healthchecks-severity</artifactId>
+            <version>${metrics-healthchecks-severity.version}</version>
         </dependency>
 
         <!-- Requires compile scope since used in the InMemoryAppender -->

--- a/src/main/java/org/kiwiproject/beta/health/SimpleMeterHealthCheck.java
+++ b/src/main/java/org/kiwiproject/beta/health/SimpleMeterHealthCheck.java
@@ -1,0 +1,57 @@
+package org.kiwiproject.beta.health;
+
+import static org.kiwiproject.metrics.health.HealthCheckResults.newHealthyResult;
+import static org.kiwiproject.metrics.health.HealthCheckResults.newUnhealthyResult;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MovingAverages;
+import com.codahale.metrics.health.HealthCheck;
+import lombok.extern.slf4j.Slf4j;
+import org.kiwiproject.beta.metrics.NamedMeter;
+import org.kiwiproject.metrics.health.HealthCheckResults;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Very simple health check that checks if a {@link Meter} has any errors in the last 15 minutes, calculated
+ * using the 15-minute rate from the meter. The returned results are built using {@link HealthCheckResults} so
+ * they contain a "severity" detail.
+ *
+ * @implNote If the {@link Meter} from Metrics library uses exponentially-weighted moving averages, it is
+ * actually not trivial to compute an exact number of errors in the last N time units. Here, this is using
+ * the 15-minute rate from the supplied meter and using that to estimate the number of errors. See specifically
+ * {@link com.codahale.metrics.MovingAverages} and {@link Meter#Meter(MovingAverages)}.
+ */
+@Slf4j
+public class SimpleMeterHealthCheck extends HealthCheck {
+
+    private static final String HEALTHY_MESSAGE = "No errors in the last 15 minutes";
+    private static final String UNHEALTHY_MESSAGE = "Some errors in the last 15 minutes";
+    private static final long NUM_SECONDS_IN_15_MINUTES = TimeUnit.MINUTES.toSeconds(15);
+
+    private final NamedMeter meter;
+
+    public SimpleMeterHealthCheck(String name, Meter meter) {
+        this.meter = NamedMeter.of(name, meter);
+    }
+
+    @Override
+    protected Result check() {
+        if (hasAnyErrorsInLast15Minutes(meter)) {
+            return newUnhealthyResult(UNHEALTHY_MESSAGE);
+        }
+
+        return newHealthyResult(HEALTHY_MESSAGE);
+    }
+
+    private static boolean hasAnyErrorsInLast15Minutes(NamedMeter meter) {
+        double estimatedErrorCount = meter.getFifteenMinuteRate() * NUM_SECONDS_IN_15_MINUTES;
+
+        LOG.trace("Meter {}: 15 minute rate : {} , estimated error count: {}",
+                meter.getName(),
+                meter.getFifteenMinuteRate(),
+                estimatedErrorCount);
+
+        return estimatedErrorCount >= 1.0;
+    }
+}

--- a/src/main/java/org/kiwiproject/beta/metrics/NamedMeter.java
+++ b/src/main/java/org/kiwiproject/beta/metrics/NamedMeter.java
@@ -1,0 +1,24 @@
+package org.kiwiproject.beta.metrics;
+
+import com.codahale.metrics.Meter;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.experimental.Delegate;
+
+/**
+ * A Metrics {@link Meter} that knows its own name.
+ */
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class NamedMeter extends Meter {
+
+    @Getter
+    private final String name;
+
+    @Delegate
+    private final Meter meter;
+
+    public static NamedMeter of(String name, Meter meter) {
+        return new NamedMeter(name, meter);
+    }
+}

--- a/src/test/java/org/kiwiproject/beta/health/SimpleMeterHealthCheckTest.java
+++ b/src/test/java/org/kiwiproject/beta/health/SimpleMeterHealthCheckTest.java
@@ -1,0 +1,64 @@
+package org.kiwiproject.beta.health;
+
+import static org.kiwiproject.metrics.health.HealthCheckResults.SEVERITY_DETAIL;
+import static org.kiwiproject.test.assertj.dropwizard.metrics.HealthCheckResultAssertions.assertThatHealthCheck;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.codahale.metrics.Meter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.kiwiproject.metrics.health.HealthStatus;
+
+import java.util.concurrent.TimeUnit;
+
+@DisplayName("SimpleMeterHealthCheck")
+class SimpleMeterHealthCheckTest {
+
+    private static final long NUM_SECONDS_IN_15_MINUTES = TimeUnit.MINUTES.toSeconds(15);
+    private static final double RATE_FOR_ONE_ERROR_IN_15_MINUTES = 1.0 / NUM_SECONDS_IN_15_MINUTES;
+
+    private SimpleMeterHealthCheck healthCheck;
+    private Meter meter;
+
+    @BeforeEach
+    void setUp() {
+        meter = mock(Meter.class);
+        healthCheck = new SimpleMeterHealthCheck("testMeterHealthCheck", meter);
+    }
+
+    @Test
+    void shouldBeHealthy_WhenNoErrors() {
+        when(meter.getFifteenMinuteRate()).thenReturn(0.0);
+
+        assertThatHealthCheck(healthCheck)
+                .isHealthy()
+                .hasMessage("No errors in the last 15 minutes")
+                .hasDetail(SEVERITY_DETAIL, HealthStatus.OK.name());
+    }
+
+    @ParameterizedTest
+    @ValueSource(doubles = {0.8, 0.9, 0.99, 0.999, 0.9999})
+    void shouldBeHealthy_WhenLessThanOneError(double fractionOfOneErrorRate) {
+        when(meter.getFifteenMinuteRate()).thenReturn(fractionOfOneErrorRate * RATE_FOR_ONE_ERROR_IN_15_MINUTES);
+
+        assertThatHealthCheck(healthCheck)
+                .isHealthy()
+                .hasMessage("No errors in the last 15 minutes")
+                .hasDetail(SEVERITY_DETAIL, HealthStatus.OK.name());
+    }
+
+    @ParameterizedTest
+    @ValueSource(doubles = {1.0, 1.1, 10.0, 25.0, 50.0})
+    void shouldBeUnhealthy_WhenSomeErrors(double multipleOfOneErrorRate) {
+        when(meter.getFifteenMinuteRate()).thenReturn(multipleOfOneErrorRate * RATE_FOR_ONE_ERROR_IN_15_MINUTES);
+
+        assertThatHealthCheck(healthCheck)
+                .isUnhealthy()
+                .hasMessage("Some errors in the last 15 minutes")
+                .hasDetail(SEVERITY_DETAIL, HealthStatus.WARN.name());
+    }
+}


### PR DESCRIPTION
* Add SimpleMeterHealthCheck, which uses a Meter as a source of errors
* Add NamedMeter, which is just a Meter but with the added ability
  that it knows its own name. Uses a Lombok @Delegate to forward method
  calls to the Meter (other than the getter for name).