### PR TITLE
Minor updates and enhancements to NamedMeter

### DIFF
--- a/src/main/java/org/kiwiproject/beta/metrics/NamedMeter.java
+++ b/src/main/java/org/kiwiproject/beta/metrics/NamedMeter.java
@@ -1,6 +1,10 @@
 package org.kiwiproject.beta.metrics;
 
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotBlank;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
+
 import com.codahale.metrics.Meter;
+import com.codahale.metrics.Metered;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,13 +16,45 @@ import lombok.experimental.Delegate;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class NamedMeter extends Meter {
 
+    /**
+     * Get the name of the {@link Meter}.
+     */
     @Getter
     private final String name;
 
+    /**
+     * Allows access to the decorated {@link Meter} instance. Normally this won't be necessary since calls to
+     * {@link Metered} methods are delegated to and because this class extends {@link Meter}, which allows it
+     * to be passed directly to any methods that accept a {@link Meter}, e.g. a {@link com.codahale.metrics.Timer}
+     * requires a {@link Meter} in one of its constructors.
+     */
+    @Getter
     @Delegate
     private final Meter meter;
 
-    public static NamedMeter of(String name, Meter meter) {
-        return new NamedMeter(name, meter);
+    /**
+     * Creates a new {@link NamedMeter} which delegates to the provided {@link Meter}.
+     *
+     * @param name          the name for this meter
+     * @param meterDelegate the {@link Meter} delegate that method calls will be forwarded to
+     * @return a new instance
+     */
+    public static NamedMeter of(String name, Meter meterDelegate) {
+        checkArgumentNotBlank(name, "name must not be blank");
+        checkArgumentNotNull(meterDelegate, "meterDelegate must not be null");
+
+        return new NamedMeter(name, meterDelegate);
     }
+
+    /**
+     * @return the name of this Meter
+     * @implNote This does not include any additional information from the Meter, because calling the methods
+     * in a Meter cause changes to occur internally (since it is time-dependent) and a {@code toString()} should
+     * not cause any internal state changes in an object.
+     */
+    @Override
+    public String toString() {
+        return name;
+    }
+
 }

--- a/src/test/java/org/kiwiproject/beta/metrics/NamedMeterTest.java
+++ b/src/test/java/org/kiwiproject/beta/metrics/NamedMeterTest.java
@@ -1,0 +1,61 @@
+package org.kiwiproject.beta.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import com.codahale.metrics.Meter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+@DisplayName("NamedMeter")
+class NamedMeterTest {
+
+    @Test
+    void shouldCreateFromMeter() {
+        var meter = new Meter();
+        var namedMeter = NamedMeter.of("testMeter", meter);
+
+        assertThat(namedMeter.getName()).isEqualTo("testMeter");
+        assertThat(namedMeter.getMeter()).isSameAs(meter);
+    }
+
+    @ParameterizedTest(name = "[{index}] name=\"{0}\", meter={1}")
+    @MethodSource("invalidFactoryMethodArgs")
+    void shouldNotCreateFromInvalidArguments(String name, Meter meter, String expectedErrorMessage) {
+        assertThatIllegalArgumentException().isThrownBy(() -> NamedMeter.of(name, meter))
+                .withMessage(expectedErrorMessage);
+    }
+
+    static Stream<Arguments> invalidFactoryMethodArgs() {
+        // overriding toString in this Meter so that the test display name renders nicely
+        var meter = new Meter() {
+            @Override
+            public String toString() {
+                return "[a non-null meter]";
+            }
+        };
+
+        var nameError = "name must not be blank";
+        var meterError = "meterDelegate must not be null";
+
+        return Stream.<Arguments>builder()
+                .add(arguments(null, meter, nameError))
+                .add(arguments("", meter, nameError))
+                .add(arguments(" ", meter, nameError))
+                .add(arguments("testMeter", null, meterError))
+                .build();
+    }
+
+    @Test
+    void shouldReturnNameAsToString() {
+        var name = "theMeter";
+        var namedMeter = NamedMeter.of(name, new Meter());
+        assertThat(namedMeter).hasToString(name);
+    }
+}


### PR DESCRIPTION
* Don't allow a NamedMeter to be created with invalid arguments
* Add a getter to provide direct access to the delegate Meter, if it is
  ever needed
* Implement a toString() to return the name
* Add some javadocs