### PR TITLE
Extract local var for 15-minute rate in SimpleMeterHealthCheck

### DIFF
--- a/src/main/java/org/kiwiproject/beta/health/SimpleMeterHealthCheck.java
+++ b/src/main/java/org/kiwiproject/beta/health/SimpleMeterHealthCheck.java
@@ -45,11 +45,12 @@ public class SimpleMeterHealthCheck extends HealthCheck {
     }
 
     private static boolean hasAnyErrorsInLast15Minutes(NamedMeter meter) {
-        double estimatedErrorCount = meter.getFifteenMinuteRate() * NUM_SECONDS_IN_15_MINUTES;
+        var fifteenMinuteRate = meter.getFifteenMinuteRate();
+        double estimatedErrorCount = fifteenMinuteRate * NUM_SECONDS_IN_15_MINUTES;
 
         LOG.trace("Meter {}: 15 minute rate : {} , estimated error count: {}",
                 meter.getName(),
-                meter.getFifteenMinuteRate(),
+                fifteenMinuteRate,
                 estimatedErrorCount);
 
         return estimatedErrorCount >= 1.0;


### PR DESCRIPTION
* Extract a local variable instead of calling getFiveMinuteRate multiple
  times. The reason is that, in a Meter, subsequent calls to the same
  method will always return a different value, since Meters are time-
  dependent.