### PR TITLE
Make build consistent in defining branches

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,8 +1,7 @@
 name: build
 on:
   push:
-    branches:
-      - main
+    branches: [ main ]
   pull_request:
     types: [ opened, synchronize, reopened ]
 jobs:


### PR DESCRIPTION
Change maven.yml to use an array for on -> push -> branches

Ok, it's really another minor thing to finally get Sonar to do the
first analysis...geez.