### PR TITLE
Add project description, URL, inception year, and SCM info to POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,18 @@
     <artifactId>kiwi-beta</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <name>Kiwi Beta (Experimental Code)</name>
+    <description>
+        Experimental code that might eventually move into kiwi, or just to try something out...
+    </description>
+    <url>https://github.com/sleberknight/kiwi-beta</url>
+    <inceptionYear>2021</inceptionYear>
+
+    <scm>
+        <connection>scm:git:https://github.com/sleberknight/kiwi-beta.git</connection>
+        <developerConnection>scm:git:git@github.com:sleberknight/kiwi-beta.git</developerConnection>
+        <url>https://github.com/sleberknight/kiwi-beta</url>
+        <tag>HEAD</tag>
+    </scm>
 
     <properties>
         <kiwi-bom.version>0.6.0</kiwi-bom.version>


### PR DESCRIPTION
I am hoping that, in addition to making the POM better, this will
make Sonar update its links and project description which are currently
incorrect...not sure where exactly it got them from, e.g. the URL that
Sonar says is the homepage for kiwi-beta is:

https://github.com/kiwiproject/kiwi-parent/kiwi-beta

which is not even valid.