### PR TITLE
Bump kiwiproject library versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,13 +38,13 @@
 
         <!-- Need explicit Dropwizard version since dropwizard-util isn't defined in kiwi-bom 0.4.0 -->
         <dropwizard.version>2.0.28</dropwizard.version>
-        <kiwi.version>1.2.0</kiwi.version>
-        <metrics-healthchecks-severity.version>1.0.2</metrics-healthchecks-severity.version>
+        <kiwi.version>1.2.1</kiwi.version>
+        <metrics-healthchecks-severity.version>1.0.3</metrics-healthchecks-severity.version>
 
         <!-- Versions for optional dependencies -->
 
         <!-- Versions for test dependencies -->
-        <kiwi-test.version>1.1.2</kiwi-test.version>
+        <kiwi-test.version>1.1.3</kiwi-test.version>
         <mockito-kotlin.version>4.0.0</mockito-kotlin.version>
 
         <!--  Sonar properties -->


### PR DESCRIPTION
* Bump kiwi from 1.2.0 to 1.2.1
* Bump metrics-healthchecks-severity from 1.0.2 to 1.0.3
* Bump kiwi-test from 1.1.2 to 1.1.3