### PR TITLE
Code cleanup in DaoHelpers and adding test coverage

### DIFF
--- a/src/test/java/org/kiwiproject/beta/dao/DaoHelpersTest.java
+++ b/src/test/java/org/kiwiproject/beta/dao/DaoHelpersTest.java
@@ -66,6 +66,16 @@ class DaoHelpersTest {
         }
 
         @Test
+        void shouldAddPrimarySortAscending() {
+            pagingRequest.setPrimarySort("lastName");
+            pagingRequest.setPrimaryDirection(Sort.Direction.ASC);
+
+            DaoHelpers.addSorts(query, allowedSortFields, pagingRequest);
+
+            assertThat(query).hasToString(BASE_QUERY + " order by lastName ASC");
+        }
+
+        @Test
         void shouldAddPrimarySortDescending() {
             pagingRequest.setPrimarySort("lastName");
             pagingRequest.setPrimaryDirection(Sort.Direction.DESC);


### PR DESCRIPTION
* Change DaoHelpers so that we pass the KiwiSort directly to the
  helper method that converts the value of KiwiSort#getDirection()
  from a String to a KiwiSort.Direction and add some arg checking
  since we never expect it to be null, and always expect getDirection()
  to return a non-blank value.
* Add test to cover all cases of Sort.Direction