### PR TITLE
Reformat code in IntelliJ

### DIFF
--- a/src/main/java/org/kiwiproject/beta/dao/AllowedFields.java
+++ b/src/main/java/org/kiwiproject/beta/dao/AllowedFields.java
@@ -20,7 +20,7 @@ import java.util.Set;
 @Beta
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class AllowedFields {
-    
+
     private final Set<String> fieldNames;
     private final Map<String, String> fieldNamesToPrefixedNames;
 
@@ -32,13 +32,13 @@ public class AllowedFields {
      * the part before the last dot is considered the prefix.
      * <p>
      * Examples: firstName, u.firstName, user.firstName, account.user.firstName
-     * 
+     *
      * @param fieldNames the field names to allow
      * @return a new instance
      */
     public static AllowedFields of(String... fieldNames) {
         checkArgumentNotNull(fieldNames, "fieldNames must not be null");
-        
+
         return AllowedFields.of(Arrays.asList(fieldNames));
     }
 
@@ -50,7 +50,7 @@ public class AllowedFields {
      * the part before the last dot is considered the prefix.
      * <p>
      * Examples: firstName, u.firstName, user.firstName, account.user.firstName
-     * 
+     *
      * @param fieldNames the field names to allow
      * @return a new instance
      * @see #of(String...)
@@ -60,10 +60,10 @@ public class AllowedFields {
         checkArgument(!fieldNames.isEmpty(), "at least one field name must be specified");
 
         var fieldNameToPrefixedNameMap = fieldNames.stream()
-            .map(PrefixAndFieldName::new)
-            .collect(toUnmodifiableMap(
-                prefixAndName -> prefixAndName.fieldName, 
-                prefixAndName -> prefixAndName.prefixedFieldName));
+                .map(PrefixAndFieldName::new)
+                .collect(toUnmodifiableMap(
+                        prefixAndName -> prefixAndName.fieldName,
+                        prefixAndName -> prefixAndName.prefixedFieldName));
 
         return new AllowedFields(Set.copyOf(fieldNameToPrefixedNameMap.keySet()), fieldNameToPrefixedNameMap);
     }
@@ -89,9 +89,9 @@ public class AllowedFields {
         }
     }
 
-    /** 
+    /**
      * Checks whether the field name is allowed
-     * 
+     *
      * @param fieldName the field name
      * @return true if the given field name is allowed, false otherwise
      */
@@ -113,7 +113,7 @@ public class AllowedFields {
 
     /**
      * Checks that the field name is an allowed field.
-     * 
+     *
      * @param fieldName the field name to check
      * @throws IllegalArgumentException if the given field name is not allowed
      */
@@ -126,7 +126,7 @@ public class AllowedFields {
 
     /**
      * Checks that the prefixed field name is allowed.
-     * 
+     *
      * @param prefixedFieldName the prefixed field name to check
      * @throws IllegalArgumentException if the given prefixed field name is not allowed
      */
@@ -139,7 +139,7 @@ public class AllowedFields {
 
     /**
      * Find the prefixed field name for the given (unprefixed) field name.
-     * 
+     *
      * @param fieldName the field name to find
      * @return the full prefixed field name (e.g. u.lastName) for the given field name (e.g. lastName)
      */

--- a/src/main/java/org/kiwiproject/beta/dao/DaoHelpers.java
+++ b/src/main/java/org/kiwiproject/beta/dao/DaoHelpers.java
@@ -39,7 +39,7 @@ public class DaoHelpers {
 
     /**
      * Defines/restricts the values that can be used when generating the ordering clause.
-     * 
+     *
      * @implNote Currently this is very restrictive and will only work in certain languages
      * such as SQL or HQL.
      */
@@ -49,12 +49,12 @@ public class DaoHelpers {
          * Separates the "base" query from the order clause.
          */
         ORDER_BY(" order by "),
-        
+
         /**
          * Separator to use between fields when there is more than one sort field.
          */
         SORT_FIELD_SEPARATOR(", "),
-        
+
         /**
          * Separator to use between the sort field and sort direction.
          */
@@ -72,8 +72,8 @@ public class DaoHelpers {
      * {@link PagingRequest}.
      */
     public static void addSorts(StringBuilder query,
-            AllowedFields allowedSortFields,
-            PagingRequest pagingRequest) {
+                                AllowedFields allowedSortFields,
+                                PagingRequest pagingRequest) {
 
         checkQueryNotNull(query);
         checkAllowedSortFieldsNotNull(allowedSortFields);
@@ -105,8 +105,8 @@ public class DaoHelpers {
      * {@link KiwiSort}.
      */
     public static void addSort(StringBuilder query,
-            AllowedFields allowedSortFields,
-            KiwiSort sort) {
+                               AllowedFields allowedSortFields,
+                               KiwiSort sort) {
 
         checkQueryNotNull(query);
         checkAllowedSortFieldsNotNull(allowedSortFields);
@@ -122,9 +122,9 @@ public class DaoHelpers {
      * for the sort field and direction.
      */
     public static void addSort(StringBuilder query,
-            AllowedFields allowedSortFields,
-            String sortField,
-            @Nullable KiwiSort.Direction sortDirection) {
+                               AllowedFields allowedSortFields,
+                               String sortField,
+                               @Nullable KiwiSort.Direction sortDirection) {
 
         addSorts(query, allowedSortFields, sortField, sortDirection, null, null);
     }
@@ -134,9 +134,9 @@ public class DaoHelpers {
      * for the primary and secondary sort criteria.
      */
     public static void addSorts(StringBuilder query,
-            AllowedFields allowedSortFields,
-            KiwiSort primarySort,
-            KiwiSort secondarySort) {
+                                AllowedFields allowedSortFields,
+                                KiwiSort primarySort,
+                                KiwiSort secondarySort) {
 
         checkArgumentNotNull(primarySort, "primarySort must not be null");
         checkArgumentNotNull(secondarySort, "secondarySort must not be null");
@@ -158,10 +158,10 @@ public class DaoHelpers {
      * <p>
      * This allows for the possibility that there are no sort criteria, in
      * which case the query is not modified.
-     * 
+     *
      * @implNote If a secondary sort is specified but not a primary sort, then
-     *           a warning is logged, the secondary sort is ignored, and therefore
-     *           the query is not modified.
+     * a warning is logged, the secondary sort is ignored, and therefore
+     * the query is not modified.
      */
     public static void addSorts(
             StringBuilder query,
@@ -202,8 +202,8 @@ public class DaoHelpers {
     }
 
     private static void logWarningIfOnlySecondarySort(String primarySortField,
-            String secondarySortField,
-            @Nullable KiwiSort.Direction secondarySortDirection) {
+                                                      String secondarySortField,
+                                                      @Nullable KiwiSort.Direction secondarySortDirection) {
 
         if (onlyContainsSecondarySort(primarySortField, secondarySortField)) {
             LOG.warn("A secondary sort ({} {}) was specified without a primary sort. Ignoring.",
@@ -224,12 +224,12 @@ public class DaoHelpers {
      * <p>
      * This allows for the possibility that there are no sort criteria, in
      * which case the query is not modified.
-     * 
+     *
      * @implNote Any null values in the {@code sorts} array are filtered out
      */
     public static void addSorts(StringBuilder query,
-            AllowedFields allowedSortFields,
-            KiwiSort... sorts) {
+                                AllowedFields allowedSortFields,
+                                KiwiSort... sorts) {
 
         checkQueryNotNull(query);
         checkAllowedSortFieldsNotNull(allowedSortFields);
@@ -248,12 +248,12 @@ public class DaoHelpers {
      * <p>
      * This allows for the possibility that there are no sort criteria, in
      * which case the query is not modified.
-     * 
+     *
      * @implNote Any null values in the {@code sorts} list are filtered out
      */
     public static void addSorts(StringBuilder query,
-            AllowedFields allowedSortFields,
-            List<KiwiSort> sorts) {
+                                AllowedFields allowedSortFields,
+                                List<KiwiSort> sorts) {
 
         checkQueryNotNull(query);
         checkAllowedSortFieldsNotNull(allowedSortFields);
@@ -298,10 +298,10 @@ public class DaoHelpers {
     }
 
     private static void addSort(StringBuilder query,
-            AllowedFields allowedSortFields,
-            Connector connector,
-            String sortField,
-            @Nullable KiwiSort.Direction sortDirection) {
+                                AllowedFields allowedSortFields,
+                                Connector connector,
+                                String sortField,
+                                @Nullable KiwiSort.Direction sortDirection) {
 
         checkQueryNotNull(query);
         checkAllowedSortFieldsNotNull(allowedSortFields);

--- a/src/test/java/org/kiwiproject/beta/dao/AllowedFieldsTest.java
+++ b/src/test/java/org/kiwiproject/beta/dao/AllowedFieldsTest.java
@@ -74,7 +74,7 @@ class AllowedFieldsTest {
         }
 
         @ParameterizedTest
-        @ValueSource(strings = { ".", ".firstName", "user.lastName.", ".account.user.email.", "account.user.email." })
+        @ValueSource(strings = {".", ".firstName", "user.lastName.", ".account.user.email.", "account.user.email."})
         void shouldNotAllowIllegalFieldNamesInVarargs(String illegalName) {
             assertThatThrownBy(() -> AllowedFields.of("age", "zip", illegalName))
                     .isExactlyInstanceOf(IllegalArgumentException.class)
@@ -92,7 +92,7 @@ class AllowedFieldsTest {
         }
 
         @ParameterizedTest
-        @ValueSource(strings = { ".", ".firstName", "user.lastName.", ".account.user.email.", "account.user.email." })
+        @ValueSource(strings = {".", ".firstName", "user.lastName.", ".account.user.email.", "account.user.email."})
         void shouldNotAllowIllegalFieldNamesInCollection(String illegalName) {
             var fieldNames = new HashSet<>(Arrays.asList("age", "zip", illegalName));
             assertThatThrownBy(() -> AllowedFields.of(fieldNames))
@@ -108,7 +108,7 @@ class AllowedFieldsTest {
                     .isExactlyInstanceOf(IllegalArgumentException.class)
                     .hasMessage("fieldNames must not be null");
         }
-        
+
         @ParameterizedTest
         @EmptySource
         void shouldNotAllowEmptyFieldNamesVararg(String[] fieldNames) {

--- a/src/test/java/org/kiwiproject/beta/dao/DaoHelpersTest.java
+++ b/src/test/java/org/kiwiproject/beta/dao/DaoHelpersTest.java
@@ -265,7 +265,7 @@ class DaoHelpersTest {
         }
 
         @ParameterizedTest
-        @ValueSource(strings = { "salary", "ssn" })
+        @ValueSource(strings = {"salary", "ssn"})
         void shouldNotAddSortForDisallowedPrimarySortField(String primarySortField) {
             assertThatThrownBy(() -> DaoHelpers.addSorts(query, allowedSortFields,
                     primarySortField, KiwiSort.Direction.DESC,
@@ -278,7 +278,7 @@ class DaoHelpersTest {
         }
 
         @ParameterizedTest
-        @ValueSource(strings = { "salary", "nickname" })
+        @ValueSource(strings = {"salary", "nickname"})
         void shouldNotAddSortForDisallowedSecondarySortField(String secondarySortField) {
             assertThatThrownBy(() -> DaoHelpers.addSorts(query, allowedSortFields,
                     "lastName", KiwiSort.Direction.DESC,


### PR DESCRIPTION
Reformat the new dao code in IntelliJ to remove all the trailing
whitespace left by VS Code as well as the get the preferred alignment
in things like method parameters, etc.