### PR TITLE
Add slf4j-api explicitly as a top-level dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-commons</artifactId>
             <version>${spring-data-commons.version}</version>


### PR DESCRIPTION
It is no longer in the parent POM.

logback-classic was already in here so didn't need to add it.