### PR TITLE
Change build to use Temurin distro and JDK 17 instead of 16

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [ '11', '16' ]
+        java_version: [ '11', '17' ]
     steps:
       # Check out the project
       - uses: actions/checkout@v3
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java_version }}
-          distribution: 'adopt'
+          distribution: 'temurin'
           check-latest: true
 
       # Cache all the things


### PR DESCRIPTION
* Change from 'adopt' to 'temurin' (AdoptJDK went to Eclipse foundation
  and became Temurin)
* Change build to use JDK 11 and 17 (dropping 16)

Closes #77