### PR TITLE
Add KiwiInternetAddresses2

### DIFF
--- a/src/main/java/org/kiwiproject/beta/net/KiwiInternetAddresses2.java
+++ b/src/main/java/org/kiwiproject/beta/net/KiwiInternetAddresses2.java
@@ -1,0 +1,71 @@
+package org.kiwiproject.beta.net;
+
+import lombok.Value;
+import lombok.experimental.UtilityClass;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.function.Supplier;
+
+import com.google.common.annotations.Beta;
+
+/**
+ * Utilities related to internet addresses.
+ * <p>
+ * These utilities could be considered for kiwi's {@link org.kiwiproject.net.KiwiInternetAddresses} class.
+ */
+@Beta
+@UtilityClass
+public class KiwiInternetAddresses2 {
+
+    /**
+     * Return a {@link SimpleAddressHolder} containing a hostname and IP supplied by the given
+     * Suppliers, or falling back to the hostname and address returned by {@link InetAddress#getLocalHost()}
+     * when a Supplier returns a blank String (null, empty string, whitespace only).
+     * <p>
+     * The primary use case for this is when you might want to override the default hostname and/or IP using
+     * some external configuration such as environment variables or system properties specified via command line.
+     * The suppliers can do something like: {@code () -> environment.getenv("CUSTOM_HOST"))}.
+     *
+     * @param hostnameSupplier supplier of hostname, may return blank string
+     * @param ipSupplier       supplier of ip address, may return blank string
+     * @return a new SimpleAddressHolder instance
+     * @implNote This is a pretty narrow use case, so it most likely won't ever move into kiwi proper. The one
+     * place we actually use this is in a "core service" library which does a bunch of setup and initialization
+     * common across services. One of the specific things it does is to get the hostname and IP address to use
+     * when registering a service, e.g. to Consul. We permit specific overrides to the hostname and/or IP address
+     * via environment variables in a service host.
+     */
+    public static SimpleAddressHolder resolveLocalAddressPreferringSupplied(Supplier<String> hostnameSupplier,
+                                                                            Supplier<String> ipSupplier) {
+
+        checkArgumentNotNull(hostnameSupplier);
+        checkArgumentNotNull(ipSupplier);
+
+        var suppliedHostname = hostnameSupplier.get();
+        var suppliedIp = ipSupplier.get();
+
+        if (isBlank(suppliedHostname) || isBlank(suppliedIp)) {
+            try {
+                var localhost = InetAddress.getLocalHost();
+                var hostname = isBlank(suppliedHostname) ? localhost.getHostName() : suppliedHostname;
+                var ip = isBlank(suppliedIp) ? localhost.getHostAddress() : suppliedIp;
+                return SimpleAddressHolder.of(hostname, ip);
+            } catch (UnknownHostException e) {
+                throw new IllegalStateException(
+                    "Received an unexpected unknown host exception trying to get local host", e);
+            }
+        }
+
+        return SimpleAddressHolder.of(suppliedHostname, suppliedIp);
+    }
+
+    @Value(staticConstructor = "of")
+    public static class SimpleAddressHolder {
+        String hostname;
+        String ip;
+    }
+}

--- a/src/test/java/org/kiwiproject/beta/net/KiwiInternetAddresses2Test.java
+++ b/src/test/java/org/kiwiproject/beta/net/KiwiInternetAddresses2Test.java
@@ -1,0 +1,68 @@
+package org.kiwiproject.beta.net;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("KiwiInternetAddresses2")
+class KiwiInternetAddresses2Test {
+
+    private Supplier<String> blankStringSupplier;
+    private InetAddress localhost;
+
+    @BeforeEach
+    void setUp() throws UnknownHostException {
+        blankStringSupplier = () -> " ";
+        localhost = InetAddress.getLocalHost();
+    }
+
+    @Nested
+    class ResolveLocalAddressPreferringSupplied {
+
+        @Test
+        void shouldRequireHostnameSupplier() {
+            assertThatIllegalArgumentException().isThrownBy(
+                () -> KiwiInternetAddresses2.resolveLocalAddressPreferringSupplied(null, blankStringSupplier));
+        }
+
+        @Test
+        void shouldRequireIpSupplier() {
+            assertThatIllegalArgumentException().isThrownBy(
+                () -> KiwiInternetAddresses2.resolveLocalAddressPreferringSupplied(blankStringSupplier, null));
+        }
+
+        @Test
+        void shouldUseSuppliedHostname() {
+            var customHostname = "server1.acme.com";
+            var address = KiwiInternetAddresses2.resolveLocalAddressPreferringSupplied(() -> customHostname, blankStringSupplier);
+
+            assertThat(address.getHostname()).isEqualTo(customHostname);
+            assertThat(address.getIp()).isEqualTo(localhost.getHostAddress());
+        }
+
+        @Test
+        void shouldUseSuppliedIp() {
+            var customIp = "192.169.100.101";
+            var address = KiwiInternetAddresses2.resolveLocalAddressPreferringSupplied(blankStringSupplier, () -> customIp);
+
+            assertThat(address.getHostname()).isEqualTo(localhost.getHostName());
+            assertThat(address.getIp()).isEqualTo(customIp);
+        }
+
+        @Test
+        void shouldUseLocalhostWhenSuppliersReturnBlank() throws UnknownHostException {
+            var address = KiwiInternetAddresses2.resolveLocalAddressPreferringSupplied(blankStringSupplier, blankStringSupplier);
+
+            assertThat(address.getHostname()).isEqualTo(localhost.getHostName());
+            assertThat(address.getIp()).isEqualTo(localhost.getHostAddress());
+        }
+    }
+}


### PR DESCRIPTION
Named the same as kiwi's `KiwiInternetAddresses` but with the suffix "2" to distinguish it.