### PR TITLE
Update ManagedCamelContext to allow giving a descriptive name

### DIFF
--- a/src/main/java/org/kiwiproject/beta/dropwizard/ManagedCamelContext.java
+++ b/src/main/java/org/kiwiproject/beta/dropwizard/ManagedCamelContext.java
@@ -1,6 +1,8 @@
 package org.kiwiproject.beta.dropwizard;
 
 import static java.util.stream.Collectors.toList;
+import static org.kiwiproject.base.KiwiPreconditions.requireNotBlank;
+import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
 import static org.kiwiproject.logging.LazyLogParameterSupplier.lazy;
 
 import com.google.common.annotations.Beta;
@@ -18,25 +20,38 @@ import org.apache.camel.Route;
 @Slf4j
 public class ManagedCamelContext implements Managed {
 
+    private final String name;
     private final CamelContext camelContext;
 
+    /**
+     * Creates a new instance with a default name.
+     */
     public ManagedCamelContext(CamelContext camelContext) {
-        this.camelContext = camelContext;
+        this("camel-context-" + System.currentTimeMillis(), camelContext);
+    }
+
+    /**
+     * Creates a new instance with the given name to be used in log messages.
+     */
+    public ManagedCamelContext(String name, CamelContext camelContext) {
+        this.name = requireNotBlank(name);
+        this.camelContext = requireNotNull(camelContext);
     }
 
     @Override
     public void start() {
-        LOG.info("Starting Camel context");
+        LOG.info("Starting Camel context {}", name);
         camelContext.start();
 
-        LOG.info("Started Camel context has {} routes. Route IDs: {}",
-                lazy(() -> camelContext.getRoutes().size()),
+        LOG.info("Started Camel context {} has {} routes. Route IDs: {}",
+                name,
+                lazy(camelContext::getRoutesSize),
                 lazy(() -> camelContext.getRoutes().stream().map(Route::getId).collect(toList())));
     }
 
     @Override
     public void stop() {
-        LOG.info("Stopping Camel context");
+        LOG.info("Stopping Camel context {}", name);
         camelContext.stop();
     }
 }


### PR DESCRIPTION
If an application has more than one CamelContext, then being able to
give them names is useful when viewing log messages that contain
the name. The existing constructor creates a default name that
includes the current timestamp. It seems highly unlikely that two
CamelContexts would be created at the exact same instance in the same
JVM, so I used System#currentTimeMillis as the timestamp.

Also, add argument checking to the 2-arg constructor and change logging
to use CamelContext#getRouteSize since the #getRoutes method creates
a copy of the routes inside a synchronized block, etc. and all we need
is the size for this replacement value.