### PR TITLE
Replace deprecated jdk11 flag in Lift configuration

### DIFF
--- a/.lift.toml
+++ b/.lift.toml
@@ -1,1 +1,2 @@
-jdk11 = true
+build = "mvn"
+jdkVersion = "11"

--- a/.lift.toml
+++ b/.lift.toml
@@ -1,2 +1,1 @@
-build = "maven"
 jdkVersion = "11"

--- a/.lift.toml
+++ b/.lift.toml
@@ -1,2 +1,2 @@
-build = "mvn"
+build = "maven"
 jdkVersion = "11"


### PR DESCRIPTION
* Replace the deprecated "jdk11" boolean flag with "jdkVersion"