### PR TITLE
Add Timing utility class

### DIFF
--- a/src/main/java/org/kiwiproject/beta/time/Timing.java
+++ b/src/main/java/org/kiwiproject/beta/time/Timing.java
@@ -1,0 +1,106 @@
+package org.kiwiproject.beta.time;
+
+import com.google.common.annotations.Beta;
+
+import org.apache.commons.lang3.time.StopWatch;
+
+import java.util.function.Supplier;
+
+import lombok.Value;
+import lombok.experimental.UtilityClass;
+
+/**
+ * Timing utilities that provide a convenient way to measure elapsed time of operations.
+ */
+@Beta
+@UtilityClass
+public class Timing {
+
+    /**
+     * Represents an operation that is timed.
+     */
+    public interface Timed {
+        long getElapsedMillis();
+    }
+
+    /**
+     * Represents an operation that is timed and returns a result.
+     *
+     * @param <R> the result type
+     */
+    @Value
+    public static class TimedWithResult<R> implements Timed {
+        long elapsedMillis;
+        R result;
+    }
+
+    /**
+     * Represents an operation that is timed and returns no result.
+     */
+    @Value
+    public static class TimedNoResult implements Timed {
+        long elapsedMillis;
+    }
+
+    /**
+     * Time an operation that returns a result using {@link StopWatch}. Any exception thrown by the
+     * Supplier is propagated (not caught).
+     * <p>
+     * The {@link StopWatch} is reset before starting. It is always stopped, even if the operation
+     * throws an exception.
+     * <p>
+     * If you need the elapsed time when an exception is thrown, you can simply call
+     * {@link StopWatch#getTime()}.
+     * <p>
+     * Since {@link StopWatch} is not thread-safe, callers are responsible for ensuring
+     * thread-safety. Passing it as an argument permits timing more than one sequential operation
+     * in the same method, but could lead to problems if callers are not careful. Typical use is
+     * to instantiate the {@link StopWatch} within a method and use it only within that method.
+     *
+     * @param <R> the type of result returned by the operation
+     * @param stopWatch the StopWatch to use
+     * @param operation the operation to time
+     * @return a {@link TimedWithResult} containing the elapsed time and the result of the operation
+     */
+    public static <R> TimedWithResult<R> timeWithResult(StopWatch stopWatch, Supplier<R> operation) {
+        stopWatch.reset();
+        stopWatch.start();
+        R result;
+        try {
+            result = operation.get();
+        } finally {
+            stopWatch.stop();
+        }
+        return new TimedWithResult<>(stopWatch.getTime(), result);
+    }
+
+    /**
+     * Time an operation that does not return a result using {@link StopWatch}. Any exception thrown by the
+     * Supplier is propagated (not caught).
+     * <p>
+     * The {@link StopWatch} is reset before starting. It is always stopped, even if the operation
+     * throws an exception.
+     * <p>
+     * If you need the elapsed time when an exception is thrown, you can simply call
+     * {@link StopWatch#getTime()}.
+     * <p>
+     * Since {@link StopWatch} is not thread-safe, callers are responsible for ensuring
+     * thread-safety. Passing it as an argument permits timing more than one sequential operation
+     * in the same method, but could lead to problems if callers are not careful. Typical use is
+     * to instantiate the {@link StopWatch} within a method and use it only within that method.
+     *
+     * @param stopWatch the StopWatch to use
+     * @param operation the operation to time
+     * @return a {@link TimedNoResult} containing the elapsed time of the operation
+     */
+    public static TimedNoResult timeNoResult(StopWatch stopWatch, Runnable operation) {
+        stopWatch.reset();
+        stopWatch.start();
+        try {
+            operation.run();
+        } finally {
+            stopWatch.stop();
+        }
+        return new TimedNoResult(stopWatch.getTime());
+    }
+}

--- a/src/test/java/org/kiwiproject/beta/time/TimingTest.java
+++ b/src/test/java/org/kiwiproject/beta/time/TimingTest.java
@@ -1,0 +1,83 @@
+package org.kiwiproject.beta.time;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.apache.commons.lang3.time.StopWatch;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
+import org.kiwiproject.base.DefaultEnvironment;
+import org.kiwiproject.base.KiwiEnvironment;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Supplier;
+
+@DisplayName("Timing")
+class TimingTest {
+
+    private static KiwiEnvironment ENV = new DefaultEnvironment();
+
+    private StopWatch stopWatch;
+
+    @BeforeEach
+    void setUp() {
+        stopWatch = new StopWatch();
+    }
+
+    @RepeatedTest(10)
+    void shouldTimeOperationsThatReturnResult() {
+        Supplier<Integer> op = () -> {
+            sleepSmallRandomTime();
+            return 42 * 42;
+        };
+        var result = Timing.timeWithResult(stopWatch, op);
+
+        assertThat(result.getElapsedMillis()).isPositive();
+        assertThat(result.getResult()).isEqualTo(1764);
+        assertThat(stopWatch.isStopped()).isTrue();
+        assertThat(stopWatch.getTime()).isEqualTo(result.getElapsedMillis());
+    }
+
+    @RepeatedTest(10)
+    void shouldStopStopWatch_WhenExceptionsAreThrown_FromTimedOperationWithResult() {
+        Supplier<Integer> op = () -> {
+            sleepSmallRandomTime();
+            throw new RuntimeException("oops");
+        };
+
+        assertThatThrownBy(() -> Timing.timeWithResult(stopWatch, op))
+                .isExactlyInstanceOf(RuntimeException.class)
+                .hasMessage("oops");
+        assertThat(stopWatch.isStopped()).isTrue();
+        assertThat(stopWatch.getTime()).isPositive();
+    }
+
+    @RepeatedTest(10)
+    void shouldTimeOperationsThatDoNotReturnResult() {
+        Runnable op = TimingTest::sleepSmallRandomTime;
+        var result = Timing.timeNoResult(stopWatch, op);
+
+        assertThat(result.getElapsedMillis()).isPositive();
+        assertThat(stopWatch.isStopped()).isTrue();
+        assertThat(stopWatch.getTime()).isEqualTo(result.getElapsedMillis());
+    }
+
+    @RepeatedTest(10)
+    void shouldStopStopWatch_WhenExceptionsAreThrown_FromTimedOperationWithNoResult() {
+        Runnable op = () -> {
+            sleepSmallRandomTime();
+            throw new RuntimeException("ugh");
+        };
+
+        assertThatThrownBy(() -> Timing.timeNoResult(stopWatch, op))
+                .isExactlyInstanceOf(RuntimeException.class)
+                .hasMessage("ugh");
+        assertThat(stopWatch.isStopped()).isTrue();
+        assertThat(stopWatch.getTime()).isPositive();
+    }
+
+    private static void sleepSmallRandomTime() {
+        ENV.sleepQuietly(ThreadLocalRandom.current().nextLong(10, 20));
+    }
+}


### PR DESCRIPTION
This `Timing` utility contains methods for timing operations. It supports operations that return a result and operations that don't.

It also contains the supporting "result" classes `TimedWithResult` and `TimedNoResult`, both of which implement the `Timed` interface.