### PR TITLE
Finish tests for KiwiServletMocks; fixes to X500 matchers

### DIFF
--- a/src/main/java/org/kiwiproject/beta/test/servlet/KiwiServletMocks.java
+++ b/src/main/java/org/kiwiproject/beta/test/servlet/KiwiServletMocks.java
@@ -83,6 +83,9 @@ public class KiwiServletMocks {
         };
     }
 
+    /**
+     * Argument matcher that matches a certificate having the given subject DN.
+     */
     public static ArgumentMatcher<X509Certificate> matchesExpectedCertBySubjectDN(String subjectDn) {
 
         return cert -> {
@@ -102,18 +105,29 @@ public class KiwiServletMocks {
         return object -> {
             assertThat(object).isInstanceOf(X509Certificate[].class);
 
+            // Create an X500Principal to compare against, so that differences in whitespace are ignored.
+            // X500Principal removes whitespace between components such that "CN=John Doe, OU=Test Org"
+            // becomes "CN=John Doe,OU=Test Org".
+            var x500Principal = new X500Principal(name);
             assertThat(object)
                     .extracting(cert -> cert.getSubjectX500Principal().getName())
-                    .containsExactly(name);
+                    .containsExactly(x500Principal.getName());
 
             return true;
         };
     }
 
+    /**
+     * Argument matcher that matches a certificate having an {@link X500Principal} with the given name.
+     */
     public static ArgumentMatcher<X509Certificate> matchesExpectedCertByX500PrincipalName(String name) {
 
         return cert -> {
-            assertThat(cert.getSubjectX500Principal().getName()).isEqualTo(name);
+            // Create an X500Principal to compare against, so that differences in whitespace are ignored.
+            // X500Principal removes whitespace between components such that "CN=John Doe, OU=Test Org"
+            // becomes "CN=John Doe,OU=Test Org".
+            var x500Principal = new X500Principal(name);
+            assertThat(cert.getSubjectX500Principal().getName()).isEqualTo(x500Principal.getName());
 
             return true;
         };

--- a/src/test/java/org/kiwiproject/beta/test/servlet/KiwiServletMocksTest.java
+++ b/src/test/java/org/kiwiproject/beta/test/servlet/KiwiServletMocksTest.java
@@ -88,8 +88,6 @@ class KiwiServletMocksTest {
                     .isInstanceOf(AssertionError.class);
         }
 
-//
-
         @Test
         void shouldMatchExpectedCertArrayByX500PrincipalName() {
             var dn = "CN=John Doe, OU=Test, O=Kiwiproject, C=US";

--- a/src/test/java/org/kiwiproject/beta/test/servlet/KiwiServletMocksTest.java
+++ b/src/test/java/org/kiwiproject/beta/test/servlet/KiwiServletMocksTest.java
@@ -1,10 +1,13 @@
 package org.kiwiproject.beta.test.servlet;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.kiwiproject.beta.servlet.KiwiServletRequests;
 
 import java.security.cert.X509Certificate;
@@ -44,7 +47,90 @@ class KiwiServletMocksTest {
     @Nested
     class X509CertificateArgumentMatchers {
 
-        // TODO...
+        @Test
+        void shouldMatchExpectedCertArrayBySubjectDN() {
+            var dn = "CN=John Doe, OU=Test, O=Kiwiproject, C=US";
+            var matcher = KiwiServletMocks.matchesExpectedCertArrayBySubjectDN(dn);
+
+            var cert = KiwiServletMocks.mockX509Certificate(dn);
+            var certs = new X509Certificate[] {cert};
+            assertThat(matcher.matches(certs)).isTrue();
+        }
+
+        @Test
+        void shouldThrowWhenDoesNotMatchExpectedCertArrayBySubjectDN() {
+            var dn = "CN=John Doe, OU=Test, O=Kiwiproject, C=US";
+            var matcher = KiwiServletMocks.matchesExpectedCertArrayBySubjectDN(dn);
+
+            var cert = KiwiServletMocks.mockX509Certificate("CN=Jane Doe, OU=Test, O=Kiwiproject, C=US");
+            var certs = new X509Certificate[] {cert};
+
+            assertThatThrownBy(() -> matcher.matches(certs))
+                    .isInstanceOf(AssertionError.class);
+        }
+
+        @Test
+        void shouldMatchExpectedCertBySubjectDN() {
+            var dn = "CN=John Doe, OU=Test, O=Kiwiproject, C=US";
+            var matcher = KiwiServletMocks.matchesExpectedCertBySubjectDN(dn);
+
+            var cert = KiwiServletMocks.mockX509Certificate(dn);
+            assertThat(matcher.matches(cert)).isTrue();
+        }
+
+        @Test
+        void shouldThrowWhenDoesNotMatchExpectedCertBySubjectDN() {
+            var dn = "CN=John Doe, OU=Test, O=Kiwiproject, C=US";
+            var matcher = KiwiServletMocks.matchesExpectedCertBySubjectDN(dn);
+
+            var cert = KiwiServletMocks.mockX509Certificate("CN=Jane Doe, OU=Test, O=Kiwiproject, C=US");
+            assertThatThrownBy(() -> matcher.matches(cert))
+                    .isInstanceOf(AssertionError.class);
+        }
+
+//
+
+        @Test
+        void shouldMatchExpectedCertArrayByX500PrincipalName() {
+            var dn = "CN=John Doe, OU=Test, O=Kiwiproject, C=US";
+            var matcher = KiwiServletMocks.matchesCertArrayByX500PrincipalName(dn);
+
+            var cert = KiwiServletMocks.mockX509Certificate(dn);
+            var certs = new X509Certificate[] {cert};
+            assertThat(matcher.matches(certs)).isTrue();
+        }
+
+        @Test
+        void shouldThrowWhenDoesNotMatchExpectedCertArrayByX500PrincipalName() {
+            var dn = "CN=John Doe, OU=Test, O=Kiwiproject, C=US";
+            var matcher = KiwiServletMocks.matchesCertArrayByX500PrincipalName(dn);
+
+            var cert = KiwiServletMocks.mockX509Certificate("CN=Jane Doe, OU=Test, O=Kiwiproject, C=US");
+            var certs = new X509Certificate[] {cert};
+
+            assertThatThrownBy(() -> matcher.matches(certs))
+                    .isInstanceOf(AssertionError.class);
+        }
+
+        @Test
+        void shouldMatchExpectedCertByX500PrincipalName() {
+            var dn = "CN=John Doe, OU=Test, O=Kiwiproject, C=US";
+            var matcher = KiwiServletMocks.matchesExpectedCertByX500PrincipalName(dn);
+
+            var cert = KiwiServletMocks.mockX509Certificate(dn);
+            assertThat(matcher.matches(cert)).isTrue();
+        }
+
+        @Test
+        void shouldThrowWhenDoesNotMatchExpectedCertByX500PrincipalName() {
+            var dn = "CN=John Doe, OU=Test, O=Kiwiproject, C=US";
+            var matcher = KiwiServletMocks.matchesExpectedCertByX500PrincipalName(dn);
+
+            var cert = KiwiServletMocks.mockX509Certificate("CN=Jane Doe, OU=Test, O=Kiwiproject, C=US");
+            assertThatThrownBy(() -> matcher.matches(cert))
+                    .isInstanceOf(AssertionError.class);
+        }
+
     }
 }
 


### PR DESCRIPTION
* Add tests for the X500/509 argument matchers
* While doing this, discovered that X500Principal removes whitespace between components of the name, so update arg matcher implementations so that they create an X500Principal internally and use its name to compare against. Otherwise whitespace differences can cause the matchers to fail.

Closes #65