### PR TITLE
Add KiwiJdbcMetaData and RuntimeSQLException

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,6 +208,12 @@
         <!-- test dependencies -->
 
         <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.kiwiproject</groupId>
             <artifactId>kiwi-test</artifactId>
             <version>${kiwi-test.version}</version>

--- a/src/main/java/org/kiwiproject/beta/jdbc/KiwiJdbcMetaData.java
+++ b/src/main/java/org/kiwiproject/beta/jdbc/KiwiJdbcMetaData.java
@@ -1,0 +1,48 @@
+package org.kiwiproject.beta.jdbc;
+
+import lombok.experimental.UtilityClass;
+
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.stream.IntStream;
+
+/**
+ * Utilities relating to JDBC metadata.
+ */
+@UtilityClass
+public class KiwiJdbcMetaData {
+
+    /**
+     * Check whether a {@link ResultSet} contains a column label, ignoring case since some database systems (e.g. H2)
+     * return column metadata in all capitals, e.g. {@code FIRST_NAME} instead of {@code first_name}.
+     *
+     * @param rs          the ResultSet to check
+     * @param columnLabel the column label to look for
+     * @return true if the ResultSet contains the given column label
+     * @throws RuntimeSQLException if there was any error getting column metadata
+     */
+    public static boolean resultSetContainsColumnLabel(ResultSet rs, String columnLabel) {
+        // NOTE: column numbers in JDBC result sets are 1-based, i.e. 1, 2, ..., N
+        try {
+            var metaData = rs.getMetaData();
+            var columnCount = metaData.getColumnCount();
+            var foundColNum = IntStream.rangeClosed(1, columnCount)
+                    .filter(colNum -> metaDataColumnLabelEquals(metaData, colNum, columnLabel))
+                    .findFirst()
+                    .orElse(0);
+            return foundColNum > 0;
+        } catch (SQLException e) {
+            throw new RuntimeSQLException(e);
+        }
+    }
+
+    private static boolean metaDataColumnLabelEquals(ResultSetMetaData metaData, int colNum, String columnLabel) {
+        try {
+            return metaData.getColumnLabel(colNum).equalsIgnoreCase(columnLabel);
+        } catch (SQLException e) {
+            throw new RuntimeSQLException(e);  // this really should never happen, so just wrap in a runtime exception
+        }
+    }
+
+}

--- a/src/main/java/org/kiwiproject/beta/jdbc/RuntimeSQLException.java
+++ b/src/main/java/org/kiwiproject/beta/jdbc/RuntimeSQLException.java
@@ -1,0 +1,45 @@
+package org.kiwiproject.beta.jdbc;
+
+import org.kiwiproject.base.KiwiPreconditions;
+
+import java.sql.SQLException;
+
+/**
+ * Unchecked exception that wraps a {@link SQLException}.
+ * <p>
+ * Note: This was copied from kiwi-test. I am not sure why we
+ * put this in kiwi-test instead of kiwi. It should probably
+ * be moved to kiwi, then maybe deprecated and removed from
+ * kiwi-test, though it would not hurt anything to leave it.
+ */
+public class RuntimeSQLException extends RuntimeException {
+
+    /**
+     * Constructs an instance of this class.
+     *
+     * @param message the detail message
+     * @param cause   the {@link SQLException} which is the cause
+     */
+    public RuntimeSQLException(String message, SQLException cause) {
+        super(message, KiwiPreconditions.requireNotNull(cause));
+    }
+
+    /**
+     * Constructs an instance of this class.
+     *
+     * @param cause the {@link SQLException} which is the cause
+     */
+    public RuntimeSQLException(SQLException cause) {
+        super(KiwiPreconditions.requireNotNull(cause));
+    }
+
+    /**
+     * Returns the cause of this exception.
+     *
+     * @return the {@link SQLException} which is the cause of this exception.
+     */
+    @Override
+    public synchronized SQLException getCause() {
+        return (SQLException) super.getCause();
+    }
+}

--- a/src/test/java/org/kiwiproject/beta/jdbc/KiwiJdbcMetaDataTest.java
+++ b/src/test/java/org/kiwiproject/beta/jdbc/KiwiJdbcMetaDataTest.java
@@ -1,0 +1,96 @@
+package org.kiwiproject.beta.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.kiwiproject.beta.jdbc.KiwiJdbcMetaData.resultSetContainsColumnLabel;
+
+import org.assertj.core.api.ThrowingConsumer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.kiwiproject.test.h2.H2FileBasedDatabase;
+import org.kiwiproject.test.junit.jupiter.H2Database;
+import org.kiwiproject.test.junit.jupiter.H2FileBasedDatabaseExtension;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+@DisplayName("KiwiJdbcMetaData")
+@ExtendWith(H2FileBasedDatabaseExtension.class)
+@SuppressWarnings({"SqlDialectInspection", "SqlNoDataSourceInspection"})
+class KiwiJdbcMetaDataTest {
+
+    private DataSource dataSource;
+
+    @BeforeAll
+    static void beforeAll(@H2Database H2FileBasedDatabase database) {
+        withConnection(database.getDataSource(), conn -> {
+            var st = conn.createStatement();
+            st.execute("create table people (id integer, f_name varchar , l_name varchar, age integer)");
+
+            var ps = conn.prepareStatement("insert into people values (?, ?, ?, ?)");
+            ps.setInt(1, 42);
+            ps.setString(2, "Darrell");
+            ps.setString(3, "Cartrip");
+            ps.setInt(4, 39);
+            ps.executeUpdate();
+        });
+    }
+
+    @BeforeEach
+    void setUp(@H2Database H2FileBasedDatabase database) {
+        dataSource = database.getDataSource();
+    }
+
+    @Nested
+    class ResultSetContainsColumnLabel {
+
+        @Test
+        void shouldReturnExpectedMatches() {
+            withConnection(conn -> {
+                var st = conn.createStatement();
+                var rs = st.executeQuery("select id, f_name as first_name, l_name as last_name, age from people where id = 42");
+
+                assertAll(
+                        () -> assertThat(resultSetContainsColumnLabel(rs, "id")).isTrue(),
+                        () -> assertThat(resultSetContainsColumnLabel(rs, "f_name")).isFalse(),
+                        () -> assertThat(resultSetContainsColumnLabel(rs, "first_name")).isTrue(),
+                        () -> assertThat(resultSetContainsColumnLabel(rs, "l_name")).isFalse(),
+                        () -> assertThat(resultSetContainsColumnLabel(rs, "last_name")).isTrue(),
+                        () -> assertThat(resultSetContainsColumnLabel(rs, "age")).isTrue()
+                );
+            });
+        }
+
+        @Test
+        void shouldBeCaseInsensitive() {
+            withConnection(conn -> {
+                var st = conn.createStatement();
+                var rs = st.executeQuery("select id, f_name as first_name, l_name as last_name, age from people where id = 42");
+
+                assertAll(
+                        () -> assertThat(resultSetContainsColumnLabel(rs, "ID")).isTrue(),
+                        () -> assertThat(resultSetContainsColumnLabel(rs, "FIRST_NAME")).isTrue(),
+                        () -> assertThat(resultSetContainsColumnLabel(rs, "LAST_NAME")).isTrue(),
+                        () -> assertThat(resultSetContainsColumnLabel(rs, "AGE")).isTrue()
+                );
+            });
+        }
+    }
+
+    private void withConnection(ThrowingConsumer<Connection> connectionConsumer) {
+        withConnection(dataSource, connectionConsumer);
+    }
+
+    private static void withConnection(DataSource dataSource, ThrowingConsumer<Connection> connectionConsumer) {
+        try (var conn = dataSource.getConnection()) {
+            connectionConsumer.accept(conn);
+        } catch (SQLException e) {
+            throw new RuntimeSQLException(e);
+        }
+    }
+}

--- a/src/test/java/org/kiwiproject/beta/jdbc/RuntimeSQLExceptionTest.java
+++ b/src/test/java/org/kiwiproject/beta/jdbc/RuntimeSQLExceptionTest.java
@@ -1,0 +1,42 @@
+package org.kiwiproject.beta.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+
+@DisplayName("RuntimeSQLException")
+class RuntimeSQLExceptionTest {
+
+    // NOTE:
+    // When comparing SQLException, some shenanigans is necessary because SQLException
+    // extends Exception and implements Iterable<Throwable>, so it causes ambiguity in the
+    // call to AssertJ's assertThat. By explicitly declaring the type to be Throwable, we
+    // can inform AssertJ how we want to perform the comparison. I have no idea whatsoever
+    // why the usual Exception causal chain mechanism wasn't good enough for SQLException.
+    // It was introduced in Java 1.6, and I can't find any reason or historical references
+    // for this design choice. It seems completely unnecessary, since you can chain exceptions
+    // via their cause.
+
+    @Test
+    void shouldConstructWithSQLException() {
+        var sqlEx = new SQLException("FK violation");
+        var runtimeSQLException = new RuntimeSQLException(sqlEx);
+
+        assertThat(runtimeSQLException.getMessage()).contains(sqlEx.getMessage());
+        Throwable cause = runtimeSQLException.getCause();  // see NOTE
+        assertThat(cause).isSameAs(sqlEx);
+    }
+
+    @Test
+    void shouldConstructWithMessageAndSQLException() {
+        var sqlEx = new SQLException("Unique constraint violation");
+        var runtimeSQLException = new RuntimeSQLException("Wrapper", sqlEx);
+
+        assertThat(runtimeSQLException.getMessage()).isEqualTo("Wrapper");
+        Throwable cause = runtimeSQLException.getCause();  // see NOTE
+        assertThat(cause).isSameAs(sqlEx);
+    }
+}


### PR DESCRIPTION
* Add KiwiJdbcMetaData utility class with one method to check if a ResultSet contains a specified column label.
* Add RuntimeSQLException (copied from kiwi-test because, for some reason we put it there instead of in kiwi).