### PR TITLE
Refactor RuntimeSQLExceptionTest to use chaining

### DIFF
--- a/src/test/java/org/kiwiproject/beta/jdbc/RuntimeSQLExceptionTest.java
+++ b/src/test/java/org/kiwiproject/beta/jdbc/RuntimeSQLExceptionTest.java
@@ -10,24 +10,14 @@ import java.sql.SQLException;
 @DisplayName("RuntimeSQLException")
 class RuntimeSQLExceptionTest {
 
-    // NOTE:
-    // When comparing SQLException, some shenanigans is necessary because SQLException
-    // extends Exception and implements Iterable<Throwable>, so it causes ambiguity in the
-    // call to AssertJ's assertThat. By explicitly declaring the type to be Throwable, we
-    // can inform AssertJ how we want to perform the comparison. I have no idea whatsoever
-    // why the usual Exception causal chain mechanism wasn't good enough for SQLException.
-    // It was introduced in Java 1.6, and I can't find any reason or historical references
-    // for this design choice. It seems completely unnecessary, since you can chain exceptions
-    // via their cause.
-
     @Test
     void shouldConstructWithSQLException() {
         var sqlEx = new SQLException("FK violation");
         var runtimeSQLException = new RuntimeSQLException(sqlEx);
 
-        assertThat(runtimeSQLException.getMessage()).contains(sqlEx.getMessage());
-        Throwable cause = runtimeSQLException.getCause();  // see NOTE
-        assertThat(cause).isSameAs(sqlEx);
+        assertThat(runtimeSQLException)
+                .hasMessageContaining(sqlEx.getMessage())
+                .hasCauseReference(sqlEx);
     }
 
     @Test
@@ -35,8 +25,8 @@ class RuntimeSQLExceptionTest {
         var sqlEx = new SQLException("Unique constraint violation");
         var runtimeSQLException = new RuntimeSQLException("Wrapper", sqlEx);
 
-        assertThat(runtimeSQLException.getMessage()).isEqualTo("Wrapper");
-        Throwable cause = runtimeSQLException.getCause();  // see NOTE
-        assertThat(cause).isSameAs(sqlEx);
+        assertThat(runtimeSQLException)
+                .hasMessage("Wrapper")
+                .hasCauseReference(sqlEx);
     }
 }


### PR DESCRIPTION
By changing the assertions on the RuntimeSQLException to chain, we can avoid the 'shenanigans' og having to declare it as a Throwable to avoid ambiguity in Assertions#assertThat. Plus, it's cleaner code that better communicates the intent. And, as much as I love to write comments explaining arcane weirdness, it's better not to need them at all.