### PR TITLE
Add TimestampingLogger - a Logger that logs elapsed time between logs

### DIFF
--- a/src/main/java/org/kiwiproject/beta/slf4j/TimestampingLogger.java
+++ b/src/main/java/org/kiwiproject/beta/slf4j/TimestampingLogger.java
@@ -81,11 +81,11 @@ public class TimestampingLogger {
         if (previousTimestamp > 0) {
             var diffInNanos = now - previousTimestamp;
             KiwiSlf4j.log(logger, level,
-                    " -- Time spent (since previous log): {} nanoseconds / {} millis",
+                    "[elapsed time since previous: {} nanoseconds / {} millis]",
                     diffInNanos, Duration.ofNanos(diffInNanos).toMillis());
         } else {
             KiwiSlf4j.log(logger, level,
-                    " -- Time spent (since previous log): N/A (no previous timestamp)");
+                    "[elapsed time since previous: N/A (no previous timestamp)]");
         }
     }
 
@@ -136,11 +136,11 @@ public class TimestampingLogger {
         if (previousTimestamp > 0) {
             var diffInNanos = now - previousTimestamp;
             KiwiSlf4j.log(logger, level,
-                    "{} -- Time spent (since previous log): {} nanoseconds / {} millis",
+                    "{} [elapsed time since previous: {} nanoseconds / {} millis]",
                     formattedMessage, diffInNanos, Duration.ofNanos(diffInNanos).toMillis());
         } else {
             KiwiSlf4j.log(logger, level,
-                    "{} -- Time spent (since previous log): N/A (no previous timestamp)",
+                    "{} [elapsed time since previous: N/A (no previous timestamp)]",
                     formattedMessage);
         }
     }

--- a/src/main/java/org/kiwiproject/beta/slf4j/TimestampingLogger.java
+++ b/src/main/java/org/kiwiproject/beta/slf4j/TimestampingLogger.java
@@ -90,49 +90,49 @@ public class TimestampingLogger {
     }
 
     /**
-     * Logs a message including elapsed time message at TRACE level.
+     * Logs a message at TRACE level and appends an elapsed time message.
      *
      * @param message the message or message template
      * @param args    the arguments to the message template, if any
-     * @see #logEmbeddingElapsed(Level, String, Object...)
+     * @see #logAppendingElapsed(Level, String, Object...)
      */
-    public void traceLogEmbeddingElapsed(String message, Object... args) {
-        logEmbeddingElapsed(Level.TRACE, message, args);
+    public void traceLogAppendingElapsed(String message, Object... args) {
+        logAppendingElapsed(Level.TRACE, message, args);
     }
 
     /**
-     * Logs a message including elapsed time message at DEBUG level.
+     * Logs a message at DEBUG level and appends an elapsed time message.
      *
      * @param message the message or message template
      * @param args    the arguments to the message template, if any
-     * @see #logEmbeddingElapsed(Level, String, Object...)
+     * @see #logAppendingElapsed(Level, String, Object...)
      */
-    public void debugLogEmbeddingElapsed(String message, Object... args) {
-        logEmbeddingElapsed(Level.DEBUG, message, args);
+    public void debugLogAppendingElapsed(String message, Object... args) {
+        logAppendingElapsed(Level.DEBUG, message, args);
     }
 
     /**
-     * Logs the given message along with the elapsed time since the previous log.
+     * Logs a message at the given level and appends an elapsed time message.
      * This results in a single log message containing the original message followed by the elapsed time message.
      *
      * @param level   the level at which to log the message and elapsed time message
      * @param message the message or message template
      * @param args    the arguments to the message template, if any
      */
-    public void logEmbeddingElapsed(Level level, String message, Object... args) {
+    public void logAppendingElapsed(Level level, String message, Object... args) {
         if (KiwiSlf4j.isEnabled(logger, level)) {
             var now = System.nanoTime();
             var formattedMessage = KiwiStrings.f(message, args);
-            logEmbeddedElapsedSincePreviousTimestamp(logger, level, formattedMessage, now, previousTimestamp);
+            logAppendingElapsedSincePreviousTimestamp(logger, level, formattedMessage, now, previousTimestamp);
             previousTimestamp = now;
         }
     }
 
-    private static void logEmbeddedElapsedSincePreviousTimestamp(Logger logger,
-                                                                 Level level,
-                                                                 String formattedMessage,
-                                                                 long now,
-                                                                 long previousTimestamp) {
+    private static void logAppendingElapsedSincePreviousTimestamp(Logger logger,
+                                                                  Level level,
+                                                                  String formattedMessage,
+                                                                  long now,
+                                                                  long previousTimestamp) {
         if (previousTimestamp > 0) {
             var diffInNanos = now - previousTimestamp;
             KiwiSlf4j.log(logger, level,

--- a/src/main/java/org/kiwiproject/beta/slf4j/TimestampingLogger.java
+++ b/src/main/java/org/kiwiproject/beta/slf4j/TimestampingLogger.java
@@ -1,0 +1,147 @@
+package org.kiwiproject.beta.slf4j;
+
+import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
+
+import com.google.common.annotations.Beta;
+import org.kiwiproject.base.KiwiStrings;
+import org.slf4j.Logger;
+import org.slf4j.event.Level;
+
+import javax.annotation.concurrent.NotThreadSafe;
+import java.time.Duration;
+
+/**
+ * A simple way to log timing information about a repeated operation.
+ * <p>
+ * This is intended to be used for a single logical operation which contains multiple steps, or for the same operation
+ * repeated over a collection. For example, an order operation with separate steps to find a user, create a new order
+ * linked to the user, and insert the order to a database. Or, some kind of data migration that loops over records in
+ * a source database table and writes to a new target database table.
+ * <p>
+ * <em>Currently, this is intended only to be used within a single thread.</em>
+ */
+@NotThreadSafe
+@Beta
+public class TimestampingLogger {
+
+    @SuppressWarnings("NonConstantLogger")
+    private final Logger logger;
+    private long previousTimestamp;
+
+    /**
+     * Create a new instance using the given {@link Logger}.
+     */
+    public TimestampingLogger(Logger logger) {
+        this.logger = requireNotNull(logger);
+    }
+
+    /**
+     * Logs a message and elapsed time message at TRACE level.
+     *
+     * @param message the message or message template
+     * @param args    the arguments to the message template, if any
+     * @see #logElapsed(Level, String, Object...)
+     */
+    public void traceLogElapsed(String message, Object... args) {
+        logElapsed(Level.TRACE, message, args);
+    }
+
+    /**
+     * Logs a message and elapsed time message at DEBUG level.
+     *
+     * @param message the message or message template
+     * @param args    the arguments to the message template, if any
+     * @see #logElapsed(Level, String, Object...)
+     */
+    public void debugLogElapsed(String message, Object... args) {
+        logElapsed(Level.DEBUG, message, args);
+    }
+
+    /**
+     * Logs the given message, and then logs the elapsed time since the previous log.
+     * This results in two separate log messages.
+     *
+     * @param level   the level at which to log the message and elapsed time message
+     * @param message the message or message template
+     * @param args    the arguments to the message template, if any
+     */
+    public void logElapsed(Level level, String message, Object... args) {
+        if (KiwiSlf4j.isEnabled(logger, level)) {
+            var now = System.nanoTime();
+            KiwiSlf4j.log(logger, level, message, args);
+            logElapsedSincePreviousTimestamp(logger, level, now, previousTimestamp);
+            previousTimestamp = now;
+        }
+    }
+
+    private static void logElapsedSincePreviousTimestamp(Logger logger,
+                                                         Level level,
+                                                         long now,
+                                                         long previousTimestamp) {
+        if (previousTimestamp > 0) {
+            var diffInNanos = now - previousTimestamp;
+            KiwiSlf4j.log(logger, level,
+                    " -- Time spent (since previous log): {} nanoseconds / {} millis",
+                    diffInNanos, Duration.ofNanos(diffInNanos).toMillis());
+        } else {
+            KiwiSlf4j.log(logger, level,
+                    " -- Time spent (since previous log): N/A (no previous timestamp)");
+        }
+    }
+
+    /**
+     * Logs a message including elapsed time message at TRACE level.
+     *
+     * @param message the message or message template
+     * @param args    the arguments to the message template, if any
+     * @see #logEmbeddingElapsed(Level, String, Object...)
+     */
+    public void traceLogEmbeddingElapsed(String message, Object... args) {
+        logEmbeddingElapsed(Level.TRACE, message, args);
+    }
+
+    /**
+     * Logs a message including elapsed time message at DEBUG level.
+     *
+     * @param message the message or message template
+     * @param args    the arguments to the message template, if any
+     * @see #logEmbeddingElapsed(Level, String, Object...)
+     */
+    public void debugLogEmbeddingElapsed(String message, Object... args) {
+        logEmbeddingElapsed(Level.DEBUG, message, args);
+    }
+
+    /**
+     * Logs the given message along with the elapsed time since the previous log.
+     * This results in a single log message containing the original message followed by the elapsed time message.
+     *
+     * @param level   the level at which to log the message and elapsed time message
+     * @param message the message or message template
+     * @param args    the arguments to the message template, if any
+     */
+    public void logEmbeddingElapsed(Level level, String message, Object... args) {
+        if (KiwiSlf4j.isEnabled(logger, level)) {
+            var now = System.nanoTime();
+            var formattedMessage = KiwiStrings.f(message, args);
+            logEmbeddedElapsedSincePreviousTimestamp(logger, level, formattedMessage, now, previousTimestamp);
+            previousTimestamp = now;
+        }
+    }
+
+    private static void logEmbeddedElapsedSincePreviousTimestamp(Logger logger,
+                                                                 Level level,
+                                                                 String formattedMessage,
+                                                                 long now,
+                                                                 long previousTimestamp) {
+        if (previousTimestamp > 0) {
+            var diffInNanos = now - previousTimestamp;
+            KiwiSlf4j.log(logger, level,
+                    "{} -- Time spent (since previous log): {} nanoseconds / {} millis",
+                    formattedMessage, diffInNanos, Duration.ofNanos(diffInNanos).toMillis());
+        } else {
+            KiwiSlf4j.log(logger, level,
+                    "{} -- Time spent (since previous log): N/A (no previous timestamp)",
+                    formattedMessage);
+        }
+    }
+}

--- a/src/test/java/org/kiwiproject/beta/slf4j/TimestampingLoggerTest.java
+++ b/src/test/java/org/kiwiproject/beta/slf4j/TimestampingLoggerTest.java
@@ -1,0 +1,221 @@
+package org.kiwiproject.beta.slf4j;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Index.atIndex;
+import static org.kiwiproject.collect.KiwiLists.fifth;
+import static org.kiwiproject.collect.KiwiLists.first;
+import static org.kiwiproject.collect.KiwiLists.fourth;
+import static org.kiwiproject.collect.KiwiLists.second;
+import static org.kiwiproject.collect.KiwiLists.subListExcludingFirst;
+import static org.kiwiproject.collect.KiwiLists.third;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.kiwiproject.beta.test.logback.InMemoryAppender;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+@DisplayName("TimestampingLogger")
+class TimestampingLoggerTest {
+
+    private static Logger logbackLogger;
+    private static InMemoryAppender appender;
+
+    private TimestampingLogger timestampingLogger;
+    private List<String> messages;
+
+    @BeforeAll
+    static void beforeAll() {
+        logbackLogger = (Logger) LoggerFactory.getLogger(TimestampingLoggerTest.class);
+        resetLevelToTrace(logbackLogger);
+
+        var context = (LoggerContext) LoggerFactory.getILoggerFactory();
+
+        appender = new InMemoryAppender();
+        appender.setContext(context);
+        appender.start();
+
+        logbackLogger.addAppender(appender);
+    }
+
+    @BeforeEach
+    void setUp() {
+        timestampingLogger = new TimestampingLogger(logbackLogger);
+
+        messages = List.of("At time 0", "At time 1", "At time 2", "At time 3", "At time 4");
+    }
+
+    @AfterEach
+    void tearDown() {
+        appender.clearEvents();
+        resetLevelToTrace(logbackLogger);
+    }
+
+    private static void resetLevelToTrace(Logger logger) {
+        logger.setLevel(ch.qos.logback.classic.Level.TRACE);
+    }
+
+    @AfterAll
+    static void afterAll() {
+        appender.stop();
+        logbackLogger.detachAppender(appender);
+    }
+
+    @Test
+    void shouldLogElapsedTimeWithArguments() {
+        timestampingLogger.logElapsed(Level.DEBUG, "{} created with id {}", "User", 42);
+        timestampingLogger.logElapsed(Level.DEBUG, "{} updated with id {}", "Order", 336);
+
+        List<String> eventMessages = appender.getOrderedEventMessages();
+
+        assertThat(eventMessages).hasSize(4);
+        assertThat(first(eventMessages)).isEqualTo("User created with id 42");
+        assertThat(second(eventMessages)).isEqualTo(" -- Time spent (since previous log): N/A (no previous timestamp)");
+        assertThat(third(eventMessages)).isEqualTo("Order updated with id 336");
+        assertThat(fourth(eventMessages)).startsWith(" -- Time spent (since previous log): ")
+                .contains(" nanoseconds /")
+                .endsWith(" millis");
+    }
+
+    @Test
+    void shouldNotLogElapsedTimeWhenLevelIsInactive() {
+        logbackLogger.setLevel(ch.qos.logback.classic.Level.WARN);
+
+        timestampingLogger.logElapsed(Level.INFO, "Should not see this!");
+        assertThat(appender.getOrderedEventMessages()).isEmpty();
+    }
+
+    @Test
+    void shouldTraceLogElapsedTime() {
+        messages.forEach(message -> timestampingLogger.traceLogElapsed(message));
+        assertElapsedEventMessages(Level.TRACE);
+    }
+
+    @Test
+    void shouldDebugLogElapsedTime() {
+        messages.forEach(message -> timestampingLogger.debugLogElapsed(message));
+        assertElapsedEventMessages(Level.DEBUG);
+    }
+
+    @Test
+    void shouldLogElapsedTime() {
+        messages.forEach(message -> timestampingLogger.logElapsed(Level.INFO, message));
+        assertElapsedEventMessages(Level.INFO);
+    }
+
+    private void assertElapsedEventMessages(Level expectedLevel) {
+        List<ILoggingEvent> orderedEvents = appender.getOrderedEvents();
+        var expectedLogbackLevel = ch.qos.logback.classic.Level.convertAnSLF4JLevel(expectedLevel);
+        assertThat(orderedEvents)
+                .describedAs("All events should have level %s", expectedLevel)
+                .isNotEmpty()
+                .allMatch(event -> event.getLevel() == expectedLogbackLevel);
+
+        List<String> eventMessages = appender.getOrderedEventMessages();
+        assertThat(eventMessages)
+                .describedAs("Should have 10 messages; even indices should have actual log messages")
+                .hasSize(10)
+                .contains(first(messages), atIndex(0))
+                .contains(second(messages), atIndex(2))
+                .contains(third(messages), atIndex(4))
+                .contains(fourth(messages), atIndex(6))
+                .contains(fifth(messages), atIndex(8));
+
+        var timeSpentMessages = eventMessages.stream()
+                .filter(eventMessage -> eventMessage.startsWith(" -- Time spent"))
+                .collect(toList());
+
+        assertThat(timeSpentMessages)
+                .describedAs("Should have five messages with elapsed time")
+                .hasSize(5);
+
+        assertThat(first(timeSpentMessages))
+                .describedAs("First elapsed time message should say there is no previous timestamp")
+                .isEqualTo(" -- Time spent (since previous log): N/A (no previous timestamp)");
+
+        subListExcludingFirst(timeSpentMessages).forEach(timeSpentMessage ->
+                assertThat(timeSpentMessage)
+                        .describedAs("Rest of elapsed time messages should include nanoseconds and millis")
+                        .startsWith(" -- Time spent (since previous log): ")
+                        .contains(" nanoseconds / ")
+                        .endsWith(" millis"));
+    }
+
+    @Test
+    void shouldLogEmbeddingElapsedTimeWithArguments() {
+        timestampingLogger.logEmbeddingElapsed(Level.TRACE, "{} created with id {}", "User", 24);
+        timestampingLogger.logEmbeddingElapsed(Level.TRACE, "{} updated with id {}", "Order", 84);
+
+        List<String> eventMessages = appender.getOrderedEventMessages();
+
+        assertThat(eventMessages).hasSize(2);
+        assertThat(first(eventMessages))
+                .isEqualTo("User created with id 24 -- Time spent (since previous log): N/A (no previous timestamp)");
+        assertThat(second(eventMessages))
+                .startsWith("Order updated with id 84 -- Time spent (since previous log): ")
+                .contains(" nanoseconds / ")
+                .endsWith(" millis");
+    }
+
+    @Test
+    void shouldNotLogEmbeddingElapsedTimeWhenLevelIsInactive() {
+        logbackLogger.setLevel(ch.qos.logback.classic.Level.ERROR);
+
+        timestampingLogger.logEmbeddingElapsed(Level.WARN, "Should not see this!");
+        assertThat(appender.getOrderedEventMessages()).isEmpty();
+    }
+
+    @Test
+    void shouldTraceLogEmbeddingElapsedTime() {
+        messages.forEach(message -> timestampingLogger.traceLogEmbeddingElapsed(message));
+        assertEmbeddedElapsedEventMessages(Level.TRACE);
+    }
+
+    @Test
+    void shouldDebugLogEmbeddingElapsedTime() {
+        messages.forEach(message -> timestampingLogger.debugLogEmbeddingElapsed(message));
+        assertEmbeddedElapsedEventMessages(Level.DEBUG);
+    }
+
+    @Test
+    void shouldLogEmbeddingElapsedTime() {
+        messages.forEach(message -> timestampingLogger.logEmbeddingElapsed(Level.WARN, message));
+        assertEmbeddedElapsedEventMessages(Level.WARN);
+    }
+
+    private void assertEmbeddedElapsedEventMessages(Level expectedLevel) {
+        List<ILoggingEvent> orderedEvents = appender.getOrderedEvents();
+        var expectedLogbackLevel = ch.qos.logback.classic.Level.convertAnSLF4JLevel(expectedLevel);
+        assertThat(orderedEvents)
+                .describedAs("All events should have level %s", expectedLevel)
+                .isNotEmpty()
+                .allMatch(event -> event.getLevel() == expectedLogbackLevel);
+
+        List<String> eventMessages = appender.getOrderedEventMessages();
+        assertThat(eventMessages)
+                .describedAs("Should have 5 messages")
+                .hasSize(5);
+
+        assertThat(first(eventMessages))
+                .describedAs("First embedded elapsed time message should say there is no previous timestamp")
+                .isEqualTo("At time 0 -- Time spent (since previous log): N/A (no previous timestamp)");
+
+        IntStream.range(1, 4).forEach(i ->
+                assertThat(eventMessages.get(i))
+                        .describedAs("Rest of embedded elapsed time messages should include nanoseconds and millis")
+                        .startsWith("At time " + i + " -- Time spent (since previous log): ")
+                        .contains(" nanoseconds / ")
+                        .endsWith(" millis"));
+    }
+}

--- a/src/test/java/org/kiwiproject/beta/slf4j/TimestampingLoggerTest.java
+++ b/src/test/java/org/kiwiproject/beta/slf4j/TimestampingLoggerTest.java
@@ -153,9 +153,9 @@ class TimestampingLoggerTest {
     }
 
     @Test
-    void shouldLogEmbeddingElapsedTimeWithArguments() {
-        timestampingLogger.logEmbeddingElapsed(Level.TRACE, "{} created with id {}", "User", 24);
-        timestampingLogger.logEmbeddingElapsed(Level.TRACE, "{} updated with id {}", "Order", 84);
+    void shouldLogAppendingElapsedTimeWithArguments() {
+        timestampingLogger.logAppendingElapsed(Level.TRACE, "{} created with id {}", "User", 24);
+        timestampingLogger.logAppendingElapsed(Level.TRACE, "{} updated with id {}", "Order", 84);
 
         List<String> eventMessages = appender.getOrderedEventMessages();
 
@@ -169,32 +169,32 @@ class TimestampingLoggerTest {
     }
 
     @Test
-    void shouldNotLogEmbeddingElapsedTimeWhenLevelIsInactive() {
+    void shouldNotLogAppendingElapsedTimeWhenLevelIsInactive() {
         logbackLogger.setLevel(ch.qos.logback.classic.Level.ERROR);
 
-        timestampingLogger.logEmbeddingElapsed(Level.WARN, "Should not see this!");
+        timestampingLogger.logAppendingElapsed(Level.WARN, "Should not see this!");
         assertThat(appender.getOrderedEventMessages()).isEmpty();
     }
 
     @Test
-    void shouldTraceLogEmbeddingElapsedTime() {
-        messages.forEach(message -> timestampingLogger.traceLogEmbeddingElapsed(message));
-        assertEmbeddedElapsedEventMessages(Level.TRACE);
+    void shouldTraceLogAppendingElapsedTime() {
+        messages.forEach(message -> timestampingLogger.traceLogAppendingElapsed(message));
+        assertAppendedElapsedEventMessages(Level.TRACE);
     }
 
     @Test
-    void shouldDebugLogEmbeddingElapsedTime() {
-        messages.forEach(message -> timestampingLogger.debugLogEmbeddingElapsed(message));
-        assertEmbeddedElapsedEventMessages(Level.DEBUG);
+    void shouldDebugLogAppendingElapsedTime() {
+        messages.forEach(message -> timestampingLogger.debugLogAppendingElapsed(message));
+        assertAppendedElapsedEventMessages(Level.DEBUG);
     }
 
     @Test
-    void shouldLogEmbeddingElapsedTime() {
-        messages.forEach(message -> timestampingLogger.logEmbeddingElapsed(Level.WARN, message));
-        assertEmbeddedElapsedEventMessages(Level.WARN);
+    void shouldLogAppendingElapsedTime() {
+        messages.forEach(message -> timestampingLogger.logAppendingElapsed(Level.WARN, message));
+        assertAppendedElapsedEventMessages(Level.WARN);
     }
 
-    private void assertEmbeddedElapsedEventMessages(Level expectedLevel) {
+    private void assertAppendedElapsedEventMessages(Level expectedLevel) {
         List<ILoggingEvent> orderedEvents = appender.getOrderedEvents();
         var expectedLogbackLevel = ch.qos.logback.classic.Level.convertAnSLF4JLevel(expectedLevel);
         assertThat(orderedEvents)
@@ -208,12 +208,12 @@ class TimestampingLoggerTest {
                 .hasSize(5);
 
         assertThat(first(eventMessages))
-                .describedAs("First embedded elapsed time message should say there is no previous timestamp")
+                .describedAs("First appended elapsed time message should say there is no previous timestamp")
                 .isEqualTo("At time 0 -- Time spent (since previous log): N/A (no previous timestamp)");
 
         IntStream.range(1, 4).forEach(i ->
                 assertThat(eventMessages.get(i))
-                        .describedAs("Rest of embedded elapsed time messages should include nanoseconds and millis")
+                        .describedAs("Rest of appended elapsed time messages should include nanoseconds and millis")
                         .startsWith("At time " + i + " -- Time spent (since previous log): ")
                         .contains(" nanoseconds / ")
                         .endsWith(" millis"));

--- a/src/test/java/org/kiwiproject/beta/slf4j/TimestampingLoggerTest.java
+++ b/src/test/java/org/kiwiproject/beta/slf4j/TimestampingLoggerTest.java
@@ -81,11 +81,11 @@ class TimestampingLoggerTest {
 
         assertThat(eventMessages).hasSize(4);
         assertThat(first(eventMessages)).isEqualTo("User created with id 42");
-        assertThat(second(eventMessages)).isEqualTo(" -- Time spent (since previous log): N/A (no previous timestamp)");
+        assertThat(second(eventMessages)).isEqualTo("[elapsed time since previous: N/A (no previous timestamp)]");
         assertThat(third(eventMessages)).isEqualTo("Order updated with id 336");
-        assertThat(fourth(eventMessages)).startsWith(" -- Time spent (since previous log): ")
+        assertThat(fourth(eventMessages)).startsWith("[elapsed time since previous: ")
                 .contains(" nanoseconds /")
-                .endsWith(" millis");
+                .endsWith(" millis]");
     }
 
     @Test
@@ -133,7 +133,7 @@ class TimestampingLoggerTest {
                 .contains(fifth(messages), atIndex(8));
 
         var timeSpentMessages = eventMessages.stream()
-                .filter(eventMessage -> eventMessage.startsWith(" -- Time spent"))
+                .filter(eventMessage -> eventMessage.startsWith("[elapsed time since previous:"))
                 .collect(toList());
 
         assertThat(timeSpentMessages)
@@ -142,14 +142,14 @@ class TimestampingLoggerTest {
 
         assertThat(first(timeSpentMessages))
                 .describedAs("First elapsed time message should say there is no previous timestamp")
-                .isEqualTo(" -- Time spent (since previous log): N/A (no previous timestamp)");
+                .isEqualTo("[elapsed time since previous: N/A (no previous timestamp)]");
 
         subListExcludingFirst(timeSpentMessages).forEach(timeSpentMessage ->
                 assertThat(timeSpentMessage)
                         .describedAs("Rest of elapsed time messages should include nanoseconds and millis")
-                        .startsWith(" -- Time spent (since previous log): ")
+                        .startsWith("[elapsed time since previous: ")
                         .contains(" nanoseconds / ")
-                        .endsWith(" millis"));
+                        .endsWith(" millis]"));
     }
 
     @Test
@@ -161,11 +161,11 @@ class TimestampingLoggerTest {
 
         assertThat(eventMessages).hasSize(2);
         assertThat(first(eventMessages))
-                .isEqualTo("User created with id 24 -- Time spent (since previous log): N/A (no previous timestamp)");
+                .isEqualTo("User created with id 24 [elapsed time since previous: N/A (no previous timestamp)]");
         assertThat(second(eventMessages))
-                .startsWith("Order updated with id 84 -- Time spent (since previous log): ")
+                .startsWith("Order updated with id 84 [elapsed time since previous: ")
                 .contains(" nanoseconds / ")
-                .endsWith(" millis");
+                .endsWith(" millis]");
     }
 
     @Test
@@ -209,13 +209,13 @@ class TimestampingLoggerTest {
 
         assertThat(first(eventMessages))
                 .describedAs("First appended elapsed time message should say there is no previous timestamp")
-                .isEqualTo("At time 0 -- Time spent (since previous log): N/A (no previous timestamp)");
+                .isEqualTo("At time 0 [elapsed time since previous: N/A (no previous timestamp)]");
 
         IntStream.range(1, 4).forEach(i ->
                 assertThat(eventMessages.get(i))
                         .describedAs("Rest of appended elapsed time messages should include nanoseconds and millis")
-                        .startsWith("At time " + i + " -- Time spent (since previous log): ")
+                        .startsWith("At time " + i + " [elapsed time since previous: ")
                         .contains(" nanoseconds / ")
-                        .endsWith(" millis"));
+                        .endsWith(" millis]"));
     }
 }


### PR DESCRIPTION
This is code based on something I found in several of our services, specifically in some code used to perform migrations from MongoDB to Postgres. The migration classes had basically the same static nested class that was used to log the number of records that had been migrated along with elapsed and (estimated) remaining time. Figured it might be worth putting in here for later possible inclusion into kiwi.

The original class was named  TimestampingTraceLogger and it only logged at TRACE level, and logged the elapsed time as a separate log statement. This new class is named more generically, TimestampingLogger, and allows logging at any level you want, plus provides convenience methods for TRACE and DEBUG levels. In addition, I added separate methods to allow "embedding" the elapsed time in the original log message, as opposed to having two separate log messages. Again, there are convenience methods for TRACE and DEBUG levels in addition to the method that accepts the Level to log at.