### PR TITLE
Increase timeout in ProcessHelpersTest

### DIFF
--- a/src/test/java/org/kiwiproject/beta/base/process/ProcessHelpersTest.java
+++ b/src/test/java/org/kiwiproject/beta/base/process/ProcessHelpersTest.java
@@ -117,10 +117,10 @@ class ProcessHelpersTest {
 
             // Trying to run a command that does not exist results in IOException
             var command = List.of("some", "command");
-            var processResult = ProcessHelpers.execute(processHelperSpy, command, 75, TimeUnit.MILLISECONDS);
+            var processResult = ProcessHelpers.execute(processHelperSpy, command, 250, TimeUnit.MILLISECONDS);
 
             assertThat(processResult.isTimedOut()).isFalse();
-            assertThat(processResult.getTimeoutThresholdMillis()).isEqualTo(75);
+            assertThat(processResult.getTimeoutThresholdMillis()).isEqualTo(250);
             assertThat(processResult.getExitCode()).isEmpty();
             assertThat(processResult.isSuccessfulExit()).isFalse();
             assertThat(processResult.isNotSuccessfulExit()).isTrue();


### PR DESCRIPTION
Occasionally I see timeouts in shouldHandleProcessExceptionsGracefully in ProcessHelpersTest, mainly while in Gitpod inside a browser. The current timeout is 75 milliseconds. I am guessing that the Mockito spy is causing the timeouts, since it sometimes takes time to initialize Mockito (I don't know why it takes a long time, but this is my observed behavior). For now, "fix" the problem by increasing the timeout to 250 milliseconds.