### PR TITLE
Add DefaultingFileAppenderFactory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,12 +122,22 @@
 
         <dependency>
             <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-logging</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-util</artifactId>
         </dependency>
 
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/kiwiproject/beta/dropwizard/DefaultingFileAppenderFactory.java
+++ b/src/main/java/org/kiwiproject/beta/dropwizard/DefaultingFileAppenderFactory.java
@@ -3,6 +3,7 @@ package org.kiwiproject.beta.dropwizard;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.annotations.Beta;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -45,6 +46,7 @@ import io.dropwizard.logging.layout.LayoutFactory;
  * @see FileAppenderFactory
  * @see RollingFileAppender
  */
+@Beta
 @Getter
 @Setter
 @JsonTypeName("rolling")

--- a/src/main/java/org/kiwiproject/beta/dropwizard/DefaultingFileAppenderFactory.java
+++ b/src/main/java/org/kiwiproject/beta/dropwizard/DefaultingFileAppenderFactory.java
@@ -1,0 +1,106 @@
+package org.kiwiproject.beta.dropwizard;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import org.kiwiproject.jar.KiwiJars;
+
+import java.io.File;
+import java.util.Optional;
+import java.util.TimeZone;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.rolling.RollingFileAppender;
+import ch.qos.logback.core.spi.DeferredProcessingAware;
+import io.dropwizard.logging.AppenderFactory;
+import io.dropwizard.logging.DropwizardLayout;
+import io.dropwizard.logging.FileAppenderFactory;
+import io.dropwizard.logging.async.AsyncAppenderFactory;
+import io.dropwizard.logging.filter.LevelFilterFactory;
+import io.dropwizard.logging.layout.LayoutFactory;
+
+/**
+ * A Dropwizard {@link AppenderFactory} implementation which extends {@link FileAppenderFactory} to provide default
+ * values for the current log file name, archive log file name pattern, and log format if they are not explicitly
+ * configured. Once the appender is built, these values can be retrieved from the factory instance using
+ * {@link #getCurrentLogFilename()}, {@link #getArchivedLogFilenamePattern()}, and {@link #getLogFormat()}.
+ * <p>
+ * This factory provides the same properties available in {@link FileAppenderFactory} and one additional property
+ * which allows you to easily use the default Dropwizard log format instead of the one provided here.
+ * <p>
+ * To use this in a Dropwizard application, the FQCN must be listed in a {@code META-INF/services/io.dropwizard.logging.AppenderFactory}
+ * file. Dropwizard already provides this file with its own implementations (in the {@code dropwizard-logging} JAR).
+ * This library also provides the same file with our implementation. These two files (and any others from other providers)
+ * must all be combined so the resulting file contains all implementations. We generally use the
+ * <a href="https://maven.apache.org/plugins/maven-shade-plugin/">Maven Shade Plugin</a> with the
+ * <a href="https://maven.apache.org/plugins/maven-shade-plugin/examples/resource-transformers.html#ServicesResourceTransformer">ServicesResourceTransformer</a>
+ * to combine these service files.
+ *
+ * @see AppenderFactory
+ * @see FileAppenderFactory
+ * @see RollingFileAppender
+ */
+@Getter
+@Setter
+@JsonTypeName("rolling")
+public class DefaultingFileAppenderFactory<E extends DeferredProcessingAware> extends FileAppenderFactory<E> {
+
+    private static final String DEFAULT_LOG_FORMAT = "%-5level [%date] [%thread] %logger{5}: %message%n";
+
+    /**
+     * If true, uses the default Dropwizard log format provided by {@link DropwizardLayout}.
+     */
+    private boolean useDefaultDropwizardLogFormat;
+
+    @Override
+    public Appender<E> build(LoggerContext context,
+            String applicationName,
+            LayoutFactory<E> layoutFactory,
+            LevelFilterFactory<E> levelFilterFactory,
+            AsyncAppenderFactory<E> asyncAppenderFactory) {
+
+        var nonNullApplicationName = Optional.ofNullable(applicationName).orElse("service");
+
+        if (isBlank(getCurrentLogFilename())) {
+            setCurrentLogFilename(filePathFor(nonNullApplicationName));
+        }
+
+        if (isBlank(getArchivedLogFilenamePattern())) {
+            setArchivedLogFilenamePattern(archiveFileNamePatternFor(nonNullApplicationName));
+        }
+
+        if (isBlank(getLogFormat())) {
+            var logFormat = newLogFormat(isUseDefaultDropwizardLogFormat(), getTimeZone());
+            setLogFormat(logFormat);
+        }
+
+        return super.build(context, applicationName, layoutFactory, levelFilterFactory, asyncAppenderFactory);
+    }
+
+    private static String filePathFor(String applicationName) {
+        return logPathFor(applicationName, ".log");
+    }
+
+    private static String archiveFileNamePatternFor(String applicationName) {
+        return logPathFor(applicationName, "-%d.log.gz");
+    }
+
+    private static String logPathFor(String applicationName, String suffix) {
+        var path = KiwiJars.getDirectoryPath(DefaultingFileAppenderFactory.class).orElse("./");
+        return String.join(File.separator, path, applicationName) + suffix;
+    }
+
+    private static String newLogFormat(boolean useDefaultDropwizardLogFormat, TimeZone timeZone) {
+        if (useDefaultDropwizardLogFormat) {
+            var dropwizardLayout = new DropwizardLayout(new LoggerContext(), timeZone);
+            return dropwizardLayout.getPattern();
+        }
+
+        return DEFAULT_LOG_FORMAT;
+    }
+}

--- a/src/main/resources/META-INF/services/io.dropwizard.logging.AppenderFactory
+++ b/src/main/resources/META-INF/services/io.dropwizard.logging.AppenderFactory
@@ -1,0 +1,1 @@
+org.kiwiproject.beta.dropwizard.DefaultingFileAppenderFactory

--- a/src/test/java/org/kiwiproject/beta/dropwizard/DefaultingFileAppenderFactoryTest.java
+++ b/src/test/java/org/kiwiproject/beta/dropwizard/DefaultingFileAppenderFactoryTest.java
@@ -1,0 +1,114 @@
+package org.kiwiproject.beta.dropwizard;
+
+import static java.util.Objects.nonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.Iterators;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.TimeZone;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AsyncAppenderBase;
+import ch.qos.logback.core.rolling.RollingFileAppender;
+import io.dropwizard.logging.DropwizardLayout;
+import io.dropwizard.logging.async.AsyncLoggingEventAppenderFactory;
+import io.dropwizard.logging.filter.ThresholdLevelFilterFactory;
+import io.dropwizard.logging.layout.DropwizardLayoutFactory;
+
+@DisplayName("DefaultingFileAppenderFactory")
+class DefaultingFileAppenderFactoryTest {
+
+    private AsyncAppenderBase<ILoggingEvent> appender;
+
+    @AfterEach
+    void tearDown() {
+        if (nonNull(appender) && appender.isStarted()) {
+            appender.stop();
+        }
+    }
+
+    @Test
+    void shouldProvideDefaultValues() {
+        var factory = new DefaultingFileAppenderFactory<ILoggingEvent>();
+        AsyncAppenderBase<ILoggingEvent> appender = buildAppender(factory, null);
+
+        assertThat(factory.getCurrentLogFilename()).endsWith("/service.log");
+        assertThat(factory.getArchivedLogFilenamePattern()).endsWith("/service-%d.log.gz");
+        assertThat(factory.getLogFormat()).isEqualTo("%-5level [%date] [%thread] %logger{5}: %message%n");
+
+        assertExactlyOneRollingFileAppender(appender);
+    }
+
+    @Test
+    void shouldProvideDefaultValues_UsingCustomApplicationName() {
+        var factory = new DefaultingFileAppenderFactory<ILoggingEvent>();
+        var appender = buildAppender(factory, "order-service");
+
+        assertThat(factory.getCurrentLogFilename()).endsWith("/order-service.log");
+        assertThat(factory.getArchivedLogFilenamePattern()).endsWith("/order-service-%d.log.gz");
+        assertThat(factory.getLogFormat()).isEqualTo("%-5level [%date] [%thread] %logger{5}: %message%n");
+
+        assertExactlyOneRollingFileAppender(appender);
+    }
+
+    @Test
+    void shouldUseDropwizardLayoutIfConfigured() {
+        var factory = new DefaultingFileAppenderFactory<ILoggingEvent>();
+        factory.setUseDefaultDropwizardLogFormat(true);
+        var appender = buildAppender(factory, "shipping-service");
+
+        assertThat(factory.getCurrentLogFilename()).endsWith("/shipping-service.log");
+        assertThat(factory.getArchivedLogFilenamePattern()).endsWith("/shipping-service-%d.log.gz");
+        var expectedPattern = new DropwizardLayout(new LoggerContext(), TimeZone.getTimeZone("UTC")).getPattern();
+        assertThat(factory.getLogFormat()).isEqualTo(expectedPattern);
+
+        assertExactlyOneRollingFileAppender(appender);
+    }
+
+    @Test
+    void shouldAcceptCustomValues(@TempDir Path tempDirPath) {
+        var tempDir = tempDirPath.toString();
+        var currentLogFilename = Path.of(tempDir, "log/services/invoice-service/invoice-service.log").toString();
+        var archivedLogFilenamePattern = Path.of(tempDir, "log/services/invoice-service/invoice-service-%d.log.gz").toString();
+        var logFormat = "%-5p [%d{ISO8601,UTC}] %c: %m%n%rEx";
+
+        var factory = new DefaultingFileAppenderFactory<ILoggingEvent>();
+        factory.setCurrentLogFilename(currentLogFilename);
+        factory.setArchivedLogFilenamePattern(archivedLogFilenamePattern);
+        factory.setLogFormat(logFormat);
+
+        var appender = buildAppender(factory, "invoice-service");
+
+        assertThat(factory.getCurrentLogFilename()).isEqualTo(currentLogFilename);
+        assertThat(factory.getArchivedLogFilenamePattern()).isEqualTo(archivedLogFilenamePattern);
+        assertThat(factory.getLogFormat()).isEqualTo(logFormat);
+
+        assertExactlyOneRollingFileAppender(appender);
+    }
+
+    private void assertExactlyOneRollingFileAppender(AsyncAppenderBase<ILoggingEvent> appender) {
+        var appenderIterator = appender.iteratorForAppenders();
+        var fileAppender = Iterators.getOnlyElement(appenderIterator);
+        assertThat(fileAppender).isExactlyInstanceOf(RollingFileAppender.class);
+        assertThat(fileAppender.isStarted()).isTrue();
+    }
+
+    private static AsyncAppenderBase<ILoggingEvent> buildAppender(
+            DefaultingFileAppenderFactory<ILoggingEvent> factory,
+            String applicationName) {
+
+        return (AsyncAppenderBase<ILoggingEvent>) factory.build(
+                new LoggerContext(),
+                applicationName,
+                new DropwizardLayoutFactory(),
+                new ThresholdLevelFilterFactory(),
+                new AsyncLoggingEventAppenderFactory());
+    }
+}


### PR DESCRIPTION
DefaultingFileAppenderFactory is a Dropwizard AppenderFactory extending FileAppenderFactory and provides default values for currentLogFilename, archivedLogFilenamePattern, and logFormat if not explicitly provided.

A META-INF service file is also provided containing the FQCN. This must be combined (e.g. using Maven Shade and ServicesResourceTransformer) with Dropwizard's out-of-box file, as noted in the javadoc.