### PR TITLE
Separate assertions from InMemoryAppender

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,8 +126,7 @@
         <!-- provided dependencies -->
 
         <!--
-            Requires compile (provided) scope since the InMemoryAppender currently uses AssertJ
-            to provide some test assertion helper methods.
+            Requires compile (provided) scope since the KiwiServletMocks uses AssertJ.
          -->
         <dependency>
             <groupId>org.assertj</groupId>

--- a/src/main/java/org/kiwiproject/beta/test/logback/InMemoryAppender.java
+++ b/src/main/java/org/kiwiproject/beta/test/logback/InMemoryAppender.java
@@ -2,7 +2,6 @@ package org.kiwiproject.beta.test.logback;
 
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toList;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
@@ -32,15 +31,8 @@ public class InMemoryAppender extends AppenderBase<ILoggingEvent> {
     }
 
     /**
-     * Assert this appender has the expected number of logging events, and if the assertion succeeds, return a
-     * list containing those events.
+     * {@inheritDoc}
      */
-    public List<ILoggingEvent> assertNumberOfLoggingEventsAndGet(int expectedEventCount) {
-        var events = getOrderedEvents();
-        assertThat(events).hasSize(expectedEventCount);
-        return events;
-    }
-
     @Override
     protected synchronized void append(ILoggingEvent eventObject) {
         eventMap.put(messageOrder.incrementAndGet(), eventObject);
@@ -64,17 +56,32 @@ public class InMemoryAppender extends AppenderBase<ILoggingEvent> {
         return Map.copyOf(eventMap);
     }
 
+    /**
+     * Return the logged {@link ILoggingEvent} instances.
+     *
+     * @return a list containing the logged events
+     */
     public List<ILoggingEvent> getOrderedEvents() {
         return getOrderedEventStream().collect(toList());
     }
 
+    /**
+     * Return the logged messages.
+     *
+     * @return a list containing the logged event messages
+     */
     public List<String> getOrderedEventMessages() {
         return getOrderedEventStream()
                 .map(ILoggingEvent::getFormattedMessage)
                 .collect(toList());
     }
 
-    private Stream<ILoggingEvent> getOrderedEventStream() {
+    /**
+     * Return a stream containing the logged events.
+     *
+     * @return a stream of the logged events
+     */
+    public Stream<ILoggingEvent> getOrderedEventStream() {
         return eventMap.values()
                 .stream()
                 .sorted(comparing(ILoggingEvent::getTimeStamp));

--- a/src/main/java/org/kiwiproject/beta/test/logback/InMemoryAppenderAssertions.java
+++ b/src/main/java/org/kiwiproject/beta/test/logback/InMemoryAppenderAssertions.java
@@ -1,0 +1,76 @@
+package org.kiwiproject.beta.test.logback;
+
+import static java.util.stream.Collectors.toList;
+
+import org.assertj.core.api.Assertions;
+
+import java.util.List;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+
+/**
+ * AssertJ assertions for {@link InMemoryAppender}.
+ */
+public class InMemoryAppenderAssertions {
+
+    private final InMemoryAppender appender;
+
+    private InMemoryAppenderAssertions(InMemoryAppender appender) {
+        this.appender = appender;
+    }
+
+    /**
+     * Begin assertions for an {@link InMemoryAppender}.
+     *
+     * @param appender the appender to assert against
+     * @return a new InMemoryAppenderAssertions instance
+     */
+    public static InMemoryAppenderAssertions assertThat(InMemoryAppender appender) {
+        return new InMemoryAppenderAssertions(appender);
+    }
+
+    /**
+     * Assert this appender has the expected number of logging events, and if the assertion succeeds, return a
+     * list containing those events.
+     *
+     * @return a List containining the logging events
+     */
+    public List<ILoggingEvent> hasNumberOfLoggingEventsAndGet(int expectedEventCount) {
+        hasNumberOfLoggingEvents(expectedEventCount);
+        return andGetOrderedEvents();
+    }
+
+    /**
+     * Assert this appender has the expected number of logging events, and if the assertion succeeds, return this
+     * instance to continue chaining assertions.
+     *
+     * @return this instance
+     */
+    public InMemoryAppenderAssertions hasNumberOfLoggingEvents(int expectedEventCount) {
+        var events = appender.getOrderedEvents();
+        Assertions.assertThat(events).hasSize(expectedEventCount);
+        return this;
+    }
+
+    /**
+     * Assert this appender contains the given message at least once (but possibly more than once).
+     *
+     * @param message the exact message to find
+     * @return this instance
+     */
+    public InMemoryAppenderAssertions containsMessage(String message) {
+        var messages = appender.getOrderedEvents().stream().map(ILoggingEvent::getMessage).collect(toList());
+        Assertions.assertThat(messages).contains(message);
+        return this;
+    }
+
+    /**
+     * A terminal method if you want to get the actual logging events after performing assertions, for example
+     * to perform additional inspections. Does not perform any assertions.
+     *
+     * @return a List containining the logging events
+     */
+    public List<ILoggingEvent> andGetOrderedEvents() {
+        return appender.getOrderedEvents();
+    }
+}


### PR DESCRIPTION
* Remove AssertJ dependency in InMemoryAppender by creating a new InMemoryAppenderAssertions class
* InMemoryAppenderAssertions depends on AssertJ and provides a fluent API to perform AssertJ-style assertions
* Make getOrderedEventStream method public in InMemoryAppender to permit flexibility, e.g. filtering specific events

Closes #196
Closes #200