### PR TITLE
Add test to verify we can handle if cert array contains a null cert

### DIFF
--- a/src/test/java/org/kiwiproject/beta/servlet/KiwiServletRequestsTest.java
+++ b/src/test/java/org/kiwiproject/beta/servlet/KiwiServletRequestsTest.java
@@ -175,6 +175,12 @@ class KiwiServletRequestsTest {
         void shouldReturnEmpty_WhenGivenNullOrEmptyCertArray(X509Certificate[] certs) {
             assertThat(KiwiServletRequests.firstCertificateOrEmpty(certs)).isEmpty();
         }
+
+        @Test
+        void shouldReturnEmpty_WhenCertArrayContainsNullCert() {
+            var certs = new X509Certificate[]{null};
+            assertThat(KiwiServletRequests.firstCertificateOrEmpty(certs)).isEmpty();
+        }
     }
 
 }


### PR DESCRIPTION
This really should not happen, i.e. it would mean that an HTTP(S) request has a non-empty cert array, but it contains a null certificate.