### PR TITLE
Remove commented-out 'nowarn' option from kotlin-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,8 +293,6 @@
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <version>${kotlin.version}</version>
                 <configuration>
-                    <!-- TODO Kotlin docs set nowarn=true...investigate why before doing this -->
-                    <!--<nowarn>true</nowarn>-->  <!-- Disable warnings -->
                     <args>
                         <arg>-Xjsr305=strict</arg> <!-- Enable strict mode for JSR-305 annotations -->
                     </args>


### PR DESCRIPTION
When true, the 'nowarn' option suppresses the (kotlin) compiler from displaying warnings during compilation. The default value is false, meaning it will display compiler warnings.

I've had this commented out for a while. Since warnings have not been a problem, there's no point in having this option sitting here in the POM, commented out,m and with an annoying ever-present TODO. So, removing it.