### PR TITLE
Build with 11, 17, and 20

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [ '11', '17', '19' ]
+        java_version: [ '11', '17', '20' ]
     steps:
       # Check out the project
       - uses: actions/checkout@v3


### PR DESCRIPTION
Now that Java 20 is released, use that instead of 19.

Continue to build with 11 and 17 for now.