### PR TITLE
Use internal locks in AutoDrainingCounter

### DIFF
--- a/src/main/java/org/kiwiproject/beta/concurrent/AutoDrainingCounter.java
+++ b/src/main/java/org/kiwiproject/beta/concurrent/AutoDrainingCounter.java
@@ -3,6 +3,7 @@ package org.kiwiproject.beta.concurrent;
 import static java.util.Objects.nonNull;
 
 import com.google.common.annotations.Beta;
+import lombok.Synchronized;
 import lombok.extern.slf4j.Slf4j;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -60,7 +61,8 @@ public class AutoDrainingCounter implements Closeable {
         return counter;
     }
 
-    public synchronized void start() {
+    @Synchronized
+    public void start() {
         if (counting.get()) {
             throw new IllegalStateException("counter already started");
         }
@@ -84,7 +86,12 @@ public class AutoDrainingCounter implements Closeable {
         return counting.get();
     }
 
+    @Synchronized
     public void stop() {
+        if (!isAlive()) {
+            LOG.warn("Counter is not alive; ignoring request to stop");
+            return;
+        }
         counting.set(false);
         scheduledExecutor.shutdownNow();
     }

--- a/src/test/java/org/kiwiproject/beta/concurrent/AutoDrainingCounterTest.java
+++ b/src/test/java/org/kiwiproject/beta/concurrent/AutoDrainingCounterTest.java
@@ -119,6 +119,22 @@ class AutoDrainingCounterTest {
     }
 
     @Test
+    void shouldIgnoreStop_WhenNeverStarted() {
+        counter = new AutoDrainingCounter(DRAIN_PERIOD);
+        counter.stop();
+        assertThat(counter.isAlive()).isFalse();
+    }
+
+    @Test
+    void shouldIgnoreStop_WhenAlreadyStopped() {
+        counter = AutoDrainingCounter.createAndStart(DRAIN_PERIOD);
+        counter.stop();
+        assertThat(counter.isAlive()).isFalse();
+        counter.stop();
+        assertThat(counter.isAlive()).isFalse();
+    }
+
+    @Test
     void shouldClose() {
         counter = AutoDrainingCounter.createAndStart(DRAIN_PERIOD);
         counter.close();


### PR DESCRIPTION
* Use Lombok's Synchronized annotation on both #start and #stop methods to ensure thread-safety
* Change #stop to log a warning and return if the counter is stopped. This prevents unnecessary calls to shut down the Executor.

Closes #227