### PR TITLE
Allow AccessedViaReflection to apply to "Element.TYPE"

### DIFF
--- a/src/main/java/org/kiwiproject/beta/annotation/AccessedViaReflection.java
+++ b/src/main/java/org/kiwiproject/beta/annotation/AccessedViaReflection.java
@@ -17,6 +17,10 @@ import java.lang.annotation.Target;
  * When placed on a method or constructor, indicates that the member is called via
  * reflection, and is this used and should not be considered for removal. When placed
  * on a field, indicates that the field is accessed via reflection to get or set it.
+ * When placed on a type (class, interface, annotation, enum, or record), indicates that
+ * the type may be loaded via reflection using {@link Class#forName(String)} or a similar
+ * mechanism. Placing on a type can also mean that the type and/or some or all of its
+ * members may be accessed reflectively.
  * <p>
  * When this annotation is present, you might also consider adding {@code @SuppressWarnings("unused")}.
  * This is necessary since {@link SuppressWarnings} is not {@link Inherited} so we cannot

--- a/src/main/java/org/kiwiproject/beta/annotation/AccessedViaReflection.java
+++ b/src/main/java/org/kiwiproject/beta/annotation/AccessedViaReflection.java
@@ -3,6 +3,7 @@ package org.kiwiproject.beta.annotation;
 import static java.lang.annotation.ElementType.CONSTRUCTOR;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
 
 import com.google.common.annotations.Beta;
 
@@ -22,7 +23,7 @@ import java.lang.annotation.Target;
  * include it in this annotation.
  */
 @Documented
-@Target({METHOD, CONSTRUCTOR, FIELD})
+@Target({METHOD, CONSTRUCTOR, FIELD, TYPE})
 @Retention(RetentionPolicy.SOURCE)
 @Beta
 public @interface AccessedViaReflection {

--- a/src/test/java/org/kiwiproject/beta/reflect/KiwiReflection2Test.java
+++ b/src/test/java/org/kiwiproject/beta/reflect/KiwiReflection2Test.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.kiwiproject.beta.annotation.AccessedViaReflection;
 import org.kiwiproject.beta.reflect.KiwiReflection2.JavaAccessModifier;
 
 @DisplayName("KiwiReflection2")
@@ -148,6 +149,7 @@ class KiwiReflection2Test {
     }
 
     @SuppressWarnings({"EmptyMethod", "unused"})
+    @AccessedViaReflection("methods are accessed via reflection")
     public static class MethodAccessTestClass {
         public void publicMethod() {
         }
@@ -163,46 +165,55 @@ class KiwiReflection2Test {
     }
 
     @SuppressWarnings("unused")
+    @AccessedViaReflection
     public static class PublicClass {
     }
 
     @SuppressWarnings("unused")
+    @AccessedViaReflection
     protected static class ProtectedClass {
     }
 
     @SuppressWarnings("unused")
+    @AccessedViaReflection
     private static class PrivateClass {
     }
 
     @SuppressWarnings("unused")
+    @AccessedViaReflection
     static class PackagePrivateClass {
     }
 
     @SuppressWarnings("unused")
+    @AccessedViaReflection
     public static class PublicConstructorAccessTestClass {
         public PublicConstructorAccessTestClass() {
         }
     }
 
     @SuppressWarnings("unused")
+    @AccessedViaReflection
     public static class ProtectedConstructorAccessTestClass {
         protected ProtectedConstructorAccessTestClass() {
         }
     }
 
     @SuppressWarnings("unused")
+    @AccessedViaReflection
     public static class PrivateConstructorAccessTestClass {
         private PrivateConstructorAccessTestClass() {
         }
     }
 
     @SuppressWarnings("unused")
+    @AccessedViaReflection
     public static class PackagePrivateConstructorAccessTestClass {
         PackagePrivateConstructorAccessTestClass() {
         }
     }
 
     @SuppressWarnings("unused")
+    @AccessedViaReflection("Fields are accessed via reflection")
     public static class FieldAccessTestClass {
         public String publicField;
         protected String protectedField;


### PR DESCRIPTION
* AccessedViaReflection should be permitted on classes (types)
* Add AccessedViaReflection annotation in KiwiReflection2Test (due to some false positives found by CodeQL)

Closes #246