### PR TITLE
Remove checker-qual from dependency management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,6 @@
         <!-- Versions for required/provided dependencies -->
 
         <camel.version>3.20.4</camel.version>
-        <checker-qual.version>3.34.0</checker-qual.version>
         <jakarta.xml.soap-api.version>1.4.2</jakarta.xml.soap-api.version>
         <jakarta.xml.ws-api.version>2.3.3</jakarta.xml.ws-api.version>
         <kiwi.version>2.5.0</kiwi.version>
@@ -57,13 +56,6 @@
 
     <dependencyManagement>
         <dependencies>
-
-            <dependency>
-                <groupId>org.checkerframework</groupId>
-                <artifactId>checker-qual</artifactId>
-                <version>${checker-qual.version}</version>
-            </dependency>
-
             <!--
                 NOTE:
                 Override the Kotlin version defined in kiwi-bom; this MUST come before kiwi-bom


### PR DESCRIPTION
kiwi-bom controls the version for checker-qual, so just inherit it.

Closes #255