### PR TITLE
Move array utils from KiwiReflection2 to KiwiArrays2

### DIFF
--- a/src/main/java/org/kiwiproject/beta/collect/KiwiArrays2.java
+++ b/src/main/java/org/kiwiproject/beta/collect/KiwiArrays2.java
@@ -1,0 +1,51 @@
+package org.kiwiproject.beta.collect;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
+
+import lombok.experimental.UtilityClass;
+
+import java.lang.reflect.Array;
+
+/**
+ * Utilities related to arrays.
+ * <p>
+ * These utilities can be considered for inclusion into kiwi's {@link org.kiwiproject.collect.KiwiArrays} class.
+ */
+@UtilityClass
+public class KiwiArrays2 {
+
+    /**
+     * Creates an empty array of the specified type.
+     *
+     * @param <T>  the type parameter representing the component type of the array
+     * @param type the class object representing the component type of the array
+     * @return an empty array of the specified type
+     * @throws IllegalArgumentException if type is null or is {@link Void#TYPE}
+     * @implNote This method exists because {@link Array#newInstance(Class, int)} returns Object and thus
+     * requires a cast. Using this method, code can be a little cleaner without a cast.
+     * @see Array#newInstance(Class, int)
+     */
+    public static <T> T[] emptyArray(Class<T> type) {
+        return newArray(type, 0);
+    }
+
+    /**
+     * Creates a new array of the specified type and length. All values in the array are null.
+     *
+     * @param <T>    the type parameter representing the component type of the array
+     * @param type   the class object representing the component type of the array
+     * @param length the length of the new array
+     * @return a new array of the specified type and length
+     * @throws IllegalArgumentException if type is null or is {@link Void#TYPE}, or length is negative
+     * @implNote This method exists because {@link Array#newInstance(Class, int)} returns Object and thus
+     * requires a cast. Using this method, code can be a little cleaner without a cast.
+     * @see Array#newInstance(Class, int)
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T[] newArray(Class<T> type, int length) {
+        checkArgumentNotNull(type);
+        checkArgument(length >= 0, "value must be positive or zero");
+        return (T[]) Array.newInstance(type, length);
+    }
+}

--- a/src/main/java/org/kiwiproject/beta/reflect/KiwiReflection2.java
+++ b/src/main/java/org/kiwiproject/beta/reflect/KiwiReflection2.java
@@ -1,13 +1,11 @@
 package org.kiwiproject.beta.reflect;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 
 import com.google.common.annotations.Beta;
 import lombok.experimental.UtilityClass;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-import java.lang.reflect.Array;
 import java.lang.reflect.Field;
 import java.lang.reflect.Member;
 import java.lang.reflect.Modifier;
@@ -192,36 +190,4 @@ public class KiwiReflection2 {
         return TypeInfo.ofType(type);
     }
 
-    /**
-     * Creates an empty array of the specified type.
-     *
-     * @param <T>  the type parameter representing the component type of the array
-     * @param type the class object representing the component type of the array
-     * @return an empty array of the specified type
-     * @throws IllegalArgumentException if type is null or is {@link Void#TYPE}
-     * @see Array#newInstance(Class, int)
-     * @implNote This method exists because {@link Array#newInstance(Class, int)} returns Object and thus
-     * requires a cast. Using this method, code can be a little cleaner without a cast.
-     */
-    public static <T> T[] emptyArray(Class<T> type) {
-        return newArray(type, 0);
-    }
-
-    /**
-     * Creates a new array of the specified type and length. All values in the array are null.
-     *
-     * @param <T>    the type parameter representing the component type of the array
-     * @param type   the class object representing the component type of the array
-     * @param length the length of the new array
-     * @return a new array of the specified type and length
-     * @throws IllegalArgumentException if type is null or is {@link Void#TYPE}, or length is negative
-     * @see Array#newInstance(Class, int)
-     * @implNote This method exists because {@link Array#newInstance(Class, int)} returns Object and thus
-     * requires a cast. Using this method, code can be a little cleaner without a cast.     */
-    @SuppressWarnings("unchecked")
-    public static <T> T[] newArray(Class<T> type, int length) {
-        checkArgumentNotNull(type);
-        checkArgument(length >= 0, "value must be positive or zero");
-        return (T[]) Array.newInstance(type, length);
-    }
 }

--- a/src/test/java/org/kiwiproject/beta/collect/KiwiArrays2Test.java
+++ b/src/test/java/org/kiwiproject/beta/collect/KiwiArrays2Test.java
@@ -1,0 +1,98 @@
+package org.kiwiproject.beta.collect;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.stream.Stream;
+
+@DisplayName("KiwiArrays2")
+class KiwiArrays2Test {
+
+    @Test
+    void emptyArray_withNullType_ShouldThrowIllegalArgumentException() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> KiwiArrays2.emptyArray(null));
+    }
+
+    // This exists only to have the concrete type declared (the parameterized method below tests multiple generic types)
+    @Test
+    void emptyArray_shouldReturnEmptyArray() {
+        Integer[] result = KiwiArrays2.emptyArray(Integer.class);
+
+        assertThat(result).isEmpty();
+    }
+
+    @ParameterizedTest
+    @ValueSource(classes = { Integer.class, String.class, Boolean.class })
+    <T> void emptyArray_shouldReturnEmptyArray(Class<T> type) {
+        T[] result = KiwiArrays2.emptyArray(type);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void newArray_withNullTypeAndValidLength_ShouldThrowIllegalArgumentException() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> KiwiArrays2.newArray(null, 10));
+    }
+
+    // This exists only to have the concrete type declared (the parameterized method below tests multiple generic types)
+    @Test
+    void newArray_shouldReturnArrayWithSpecifiedLength() {
+        Long[] result = KiwiArrays2.newArray(Long.class, 5);
+
+        assertThat(result).hasSize(5).containsOnlyNulls();
+    }
+
+    @Test
+    void newArray_shouldReturnArrayWithSpecifiedLength_OfZero() {
+        String[] result = KiwiArrays2.newArray(String.class, 0);
+
+        assertThat(result).isEmpty();
+    }
+
+    @ParameterizedTest
+    @MethodSource("newArrayTypeAndLengthProvider")
+    <T> void newArray_shouldReturnArrayWithSpecifiedLength(Class<T> type, int length) {
+        T[] result = KiwiArrays2.newArray(type, length);
+
+        assertThat(result).hasSize(length).containsOnlyNulls();
+    }
+
+    // This exists only to have the concrete type declared (the parameterized method below tests multiple generic types)
+    @Test
+    void newArray_withNegativeLength_shouldThrowIllegalArgumentException() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> KiwiArrays2.newArray(Double.class, -1));
+    }
+
+    @ParameterizedTest
+    @MethodSource("newArrayNegativeLengthProvider")
+    void newArray_withNegativeLength_shouldThrowIllegalArgumentException(Class<?> type, int length) {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> KiwiArrays2.newArray(type, length));
+    }
+
+    static Stream<Arguments> newArrayTypeAndLengthProvider() {
+        return Stream.of(
+                Arguments.of(Integer.class, 5),
+                Arguments.of(String.class, 10),
+                Arguments.of(Boolean.class, 25)
+        );
+    }
+
+    static Stream<Arguments> newArrayNegativeLengthProvider() {
+        return Stream.of(
+                Arguments.of(Double.class, -1),
+                Arguments.of(Character.class, -5),
+                Arguments.of(String.class, -42)
+        );
+    }
+}

--- a/src/test/java/org/kiwiproject/beta/reflect/KiwiReflection2Test.java
+++ b/src/test/java/org/kiwiproject/beta/reflect/KiwiReflection2Test.java
@@ -6,15 +6,11 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import lombok.Value;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.kiwiproject.beta.annotation.AccessedViaReflection;
 import org.kiwiproject.beta.reflect.KiwiReflection2.JavaAccessModifier;
 
@@ -22,7 +18,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 
 @DisplayName("KiwiReflection2")
 class KiwiReflection2Test {
@@ -378,86 +373,5 @@ class KiwiReflection2Test {
     static class Raw {
         List rawList;
         Map rawMap;
-    }
-
-    @Test
-    void emptyArray_withNullType_ShouldThrowIllegalArgumentException() {
-        assertThatIllegalArgumentException()
-                .isThrownBy(() -> KiwiReflection2.emptyArray(null));
-    }
-
-    // This exists only to have the concrete type declared (the parameterized method below tests multiple generic types)
-    @Test
-    void emptyArray_shouldReturnEmptyArray() {
-        Integer[] result = KiwiReflection2.emptyArray(Integer.class);
-
-        assertThat(result).isEmpty();
-    }
-
-    @ParameterizedTest
-    @ValueSource(classes = {Integer.class, String.class, Boolean.class})
-    <T> void emptyArray_shouldReturnEmptyArray(Class<T> type) {
-        T[] result = KiwiReflection2.emptyArray(type);
-
-        assertThat(result).isEmpty();
-    }
-
-    @Test
-    void newArray_withNullTypeAndValidLength_ShouldThrowIllegalArgumentException() {
-        assertThatIllegalArgumentException()
-                .isThrownBy(() -> KiwiReflection2.newArray(null, 10));
-    }
-
-    // This exists only to have the concrete type declared (the parameterized method below tests multiple generic types)
-    @Test
-    void newArray_shouldReturnArrayWithSpecifiedLength() {
-        Long[] result = KiwiReflection2.newArray(Long.class, 5);
-
-        assertThat(result).hasSize(5).containsOnlyNulls();
-    }
-
-    @Test
-    void newArray_shouldReturnArrayWithSpecifiedLength_OfZero() {
-        String[] result = KiwiReflection2.newArray(String.class, 0);
-
-        assertThat(result).isEmpty();
-    }
-
-    @ParameterizedTest
-    @MethodSource("newArrayTypeAndLengthProvider")
-    <T> void newArray_shouldReturnArrayWithSpecifiedLength(Class<T> type, int length) {
-        T[] result = KiwiReflection2.newArray(type, length);
-
-        assertThat(result).hasSize(length).containsOnlyNulls();
-    }
-
-    // This exists only to have the concrete type declared (the parameterized method below tests multiple generic types)
-    @Test
-    void newArray_withNegativeLength_shouldThrowIllegalArgumentException() {
-        assertThatIllegalArgumentException()
-                .isThrownBy(() -> KiwiReflection2.newArray(Double.class, -1));
-    }
-
-    @ParameterizedTest
-    @MethodSource("newArrayNegativeLengthProvider")
-    void newArray_withNegativeLength_shouldThrowIllegalArgumentException(Class<?> type, int length) {
-        assertThatIllegalArgumentException()
-                .isThrownBy(() -> KiwiReflection2.newArray(type, length));
-    }
-
-    static Stream<Arguments> newArrayTypeAndLengthProvider() {
-        return Stream.of(
-                Arguments.of(Integer.class, 5),
-                Arguments.of(String.class, 10),
-                Arguments.of(Boolean.class, 25)
-        );
-    }
-
-    static Stream<Arguments> newArrayNegativeLengthProvider() {
-        return Stream.of(
-                Arguments.of(Double.class, -1),
-                Arguments.of(Character.class, -5),
-                Arguments.of(String.class, -42)
-        );
     }
 }


### PR DESCRIPTION
These utilities should not have gone into KiwiReflection2. Instead, they should go in a utility class specific for arrays. Created KiwiArrays2 and moved emptyArray and newArray there.