### PR TITLE
Add JUnit ArgumentsSource to provide random capitalization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,18 @@
 
         <!-- provided dependencies -->
 
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!--
             Requires compile (provided) scope since the KiwiServletMocks uses AssertJ.
          -->

--- a/src/main/java/org/kiwiproject/beta/test/junit/jupiter/params/provider/RandomCapitalizationArgumentsProvider.java
+++ b/src/main/java/org/kiwiproject/beta/test/junit/jupiter/params/provider/RandomCapitalizationArgumentsProvider.java
@@ -1,0 +1,49 @@
+package org.kiwiproject.beta.test.junit.jupiter.params.provider;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotBlank;
+import static org.kiwiproject.beta.base.KiwiStrings2.randomCaseVariants;
+import static org.kiwiproject.beta.base.KiwiStrings2.standardCaseVariants;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.support.AnnotationConsumer;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+/**
+ * An {@link ArgumentsProvider} that provides random capitalization of an input value.
+ *
+ * @see RandomCapitalizationSource
+ */
+public class RandomCapitalizationArgumentsProvider
+        implements ArgumentsProvider, AnnotationConsumer<RandomCapitalizationSource> {
+
+    private RandomCapitalizationSource randomCapitalizationSource;
+
+    @Override
+    public void accept(RandomCapitalizationSource randomCapitalizationSource) {
+        this.randomCapitalizationSource = randomCapitalizationSource;
+    }
+
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+        var value = randomCapitalizationSource.value();
+        var count = randomCapitalizationSource.count();
+
+        checkArgumentNotBlank(value, "value must not be blank");
+        checkArgument(count > 0, "count must be greater than zero");
+
+        Set<String> variants = getCaseVariants(value, count, randomCapitalizationSource.type());
+        return variants.stream().map(Arguments::of);
+    }
+
+    private static Set<String> getCaseVariants(String value, int count, RandomCapitalizationSource.Type type) {
+        if (type == RandomCapitalizationSource.Type.RANDOM) {
+            return randomCaseVariants(value, count);
+        }
+        return standardCaseVariants(value);
+    }
+}

--- a/src/main/java/org/kiwiproject/beta/test/junit/jupiter/params/provider/RandomCapitalizationSource.java
+++ b/src/main/java/org/kiwiproject/beta/test/junit/jupiter/params/provider/RandomCapitalizationSource.java
@@ -1,0 +1,66 @@
+package org.kiwiproject.beta.test.junit.jupiter.params.provider;
+
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * {@link RandomCapitalizationSource} is an {@link ArgumentsSource} that provides values having a random capitalization
+ * of a given input for use in parameterized tests.
+ */
+@Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ArgumentsSource(RandomCapitalizationArgumentsProvider.class)
+public @interface RandomCapitalizationSource {
+
+    /**
+     * The value which will be randomly capitalized.
+     *
+     * @return the input value
+     */
+    String value();
+
+    /**
+     * The desired number of randomly capitalized values to provide.
+     * <p>
+     * The actual number provided may be less than this value if it is more than 2^N, where N is the length of
+     * the input value. See {@link org.kiwiproject.beta.base.KiwiStrings2#randomCaseVariants(String, int)} for
+     * details on this mathematical limit.
+     *
+     * @return the number of desired values
+     */
+    int count() default 3;
+
+    /**
+     * The type of capitalization to provide.
+     */
+    enum Type {
+
+        /**
+         * Provides randomly capitalized values.
+         */
+        RANDOM,
+
+        /**
+         * Provides three "standard" case variants.
+         *
+         * @see org.kiwiproject.beta.base.KiwiStrings2#standardCaseVariants(String)
+         */
+        STANDARD
+    }
+
+    /**
+     * The type of capitalized values to provide.
+     * <p>
+     * Note that when {@link Type#STANDARD} is chosen, the maximum number of values is three.
+     *
+     * @return the type
+     * @see org.kiwiproject.beta.base.KiwiStrings2#standardCaseVariants(String)
+     */
+    Type type() default Type.RANDOM;
+}

--- a/src/test/java/org/kiwiproject/beta/test/junit/jupiter/params/provider/RandomCapitalizationArgumentsProviderTest.java
+++ b/src/test/java/org/kiwiproject/beta/test/junit/jupiter/params/provider/RandomCapitalizationArgumentsProviderTest.java
@@ -1,0 +1,145 @@
+package org.kiwiproject.beta.test.junit.jupiter.params.provider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.kiwiproject.beta.test.junit.jupiter.params.provider.RandomCapitalizationSource.Type;
+import org.kiwiproject.test.junit.jupiter.params.provider.MinimalBlankStringSource;
+import org.kiwiproject.test.junit.jupiter.params.provider.RandomIntSource;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.concurrent.ThreadLocalRandom;
+
+@DisplayName("RandomCapitalizationArgumentsProvider")
+class RandomCapitalizationArgumentsProviderTest {
+
+    @ParameterizedTest
+    @ValueSource(ints = { 3, 5, 10, 25 })
+    void shouldProvideTheExpectedNumberOfRandomlyCapitalizedValues(int count) {
+        var annotation = newRandomCapitalization("error", count, Type.RANDOM);
+        var provider = newRandomCapitalizationArgumentsProvider(annotation);
+
+        var arguments = getProviderArguments(provider);
+
+        assertThat(arguments).hasSize(count);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "a", "ab", "abc", "abcd", "abcde" })
+    void shouldProvideTheMaximumMathematicallyPossibleRandomCapitalizationVariants(String value) {
+        var maxPossibleVariants = (int) Math.pow(2, value.length());
+        var count = maxPossibleVariants + 1;
+        var annotation = newRandomCapitalization(value, count, Type.RANDOM);
+        var provider = newRandomCapitalizationArgumentsProvider(annotation);
+
+        var arguments = getProviderArguments(provider);
+
+        assertThat(arguments).hasSize(maxPossibleVariants);
+    }
+
+    @Test
+    void shouldProvideTheThreeStandardCapitalizedValues_AndIgnoreCountIfSpecified() {
+        var countLargerThanThree = ThreadLocalRandom.current().nextInt(4, 21);
+        var annotation = newRandomCapitalization("success", countLargerThanThree, Type.STANDARD);
+        var provider = newRandomCapitalizationArgumentsProvider(annotation);
+
+        var arguments = getProviderArguments(provider);
+
+        assertThat(arguments).containsExactlyInAnyOrder("SUCCESS", "success", "Success");
+    }
+
+    @ParameterizedTest
+    @MinimalBlankStringSource
+    void shouldRequireValue(String value) {
+        var annotation = newRandomCapitalization(value, 3, Type.RANDOM);
+
+        var provider = newRandomCapitalizationArgumentsProvider(annotation);
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> provider.provideArguments(null))
+                .withMessage("value must not be blank");
+    }
+
+    @ParameterizedTest
+    @RandomIntSource(max = 0)
+    void shouldRequireCountGreaterThanZero(int count) {
+        var annotation = newRandomCapitalization("abc", count, Type.RANDOM);
+
+        var provider = newRandomCapitalizationArgumentsProvider(annotation);
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> provider.provideArguments(null))
+                .withMessage("count must be greater than zero");
+    }
+
+    private static RandomCapitalizationArgumentsProvider newRandomCapitalizationArgumentsProvider(
+            RandomCapitalizationSource annotation) {
+
+        var provider = new RandomCapitalizationArgumentsProvider();
+        provider.accept(annotation);
+        return provider;
+    }
+
+    private static String[] getProviderArguments(RandomCapitalizationArgumentsProvider provider) {
+        return provider.provideArguments(null)
+                .map(Arguments::get)
+                .flatMap(Arrays::stream)
+                .map(String.class::cast)
+                .toArray(String[]::new);
+    }
+
+    private static RandomCapitalizationSource newRandomCapitalization(String value, int count, Type type) {
+        return new RandomCapitalizationSource() {
+
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return RandomCapitalizationSource.class;
+            }
+
+            @Override
+            public String value() {
+                return value;
+            }
+
+            @Override
+            public int count() {
+                return count;
+            }
+
+            @Override
+            public Type type() {
+                return type;
+            }
+        };
+    }
+
+    @DisplayName("UsingTheAnnotation")
+    @Nested
+    class IntegrationTests {
+
+        @ParameterizedTest
+        @RandomCapitalizationSource("abc")
+        void shouldProvideRandomCapitalization(String input) {
+            assertThat(input).isEqualToIgnoringCase("abc");
+        }
+
+        @ParameterizedTest
+        @RandomCapitalizationSource(value = "error", type = Type.STANDARD)
+        void shouldProvideStandardCapitalization(String input) {
+            assertThat(input).isIn("error", "ERROR", "Error");
+        }
+
+        @ParameterizedTest
+        @RandomCapitalizationSource(value = "abc", count = 5)
+        void shouldProvideRandomCapitalizationWithCount(String input) {
+            assertThat(input).isEqualToIgnoringCase("abc");
+        }
+    }
+}


### PR DESCRIPTION
* Add RandomCapitalizationSource, a JUnit ArgumentsSource annotation that can be used with parameterized tests to provide random capitalization of input strings
* Add RandomCapitalizationArgumentsProvider, a JUnit ArgumentsProvider which provides the values for tests annotated with the RandomCapitalizationSource annotation
* Under the covers, uses KiwiStrings2 random case methods
* Added junit-jupiter-api and junit-jupiter-params as provided-scope dependencies, so that RandomCapitalizationSource and RandomCapitalizationArgumentsProvider can access those APIs as part of the library code (i.e. they cannot use test scope, otherwise the new code would not compile since it is in src/main). Since they are provided, it will not cause JUnit dependencies to be transitively pulled into production code, as these will (presumably) only ever be used in tests.