### PR TITLE
Add array conversion methods to KiwiArrays2

### DIFF
--- a/src/main/java/org/kiwiproject/beta/collect/KiwiArrays2.java
+++ b/src/main/java/org/kiwiproject/beta/collect/KiwiArrays2.java
@@ -1,11 +1,17 @@
 package org.kiwiproject.beta.collect;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.isNull;
+import static org.apache.commons.lang3.ClassUtils.isPrimitiveWrapper;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 
 import lombok.experimental.UtilityClass;
+import org.apache.commons.lang3.ArrayUtils;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.lang.reflect.Array;
+import java.util.Optional;
 
 /**
  * Utilities related to arrays.
@@ -48,4 +54,104 @@ public class KiwiArrays2 {
         checkArgument(length >= 0, "value must be positive or zero");
         return (T[]) Array.newInstance(type, length);
     }
+
+    /**
+     * Convert an array of primitives to an array of the corresponding wrapper type.
+     *
+     * @param primitiveArray an array of primitives
+     * @param wrapperType the wrapper type of the primitive type
+     * @param <T> the wrapper type corresponding to the input array's primitive type
+     * @return an array of the wrapper type, or {@code null} if the input array is null
+     * @throws IllegalArgumentException if the input array is not an array of primitives, or the wrapper type
+     * is not a primitive wrapper class
+     * @implNote Intentionally suppressing Sonar java:S1168 (Return an empty array instead of null) because
+     * the method is explicit that it returns null when given null input.
+     */
+    @Nullable
+    @SuppressWarnings("java:S1168")
+    public static <T> T[] primitiveToObjectArrayOrNull(@Nullable Object primitiveArray, Class<T> wrapperType) {
+        if (isNull(primitiveArray)) {
+            return null;
+        }
+
+        return primitiveToObjectArray(primitiveArray, wrapperType);
+    }
+
+    /**
+     * Convert an array of primitives to an array of the corresponding wrapper type.
+     *
+     * @param primitiveArray an array of primitives
+     * @param wrapperType the wrapper type of the primitive type
+     * @param <T> the wrapper type corresponding to the input array's primitive type
+     * @return an Optional containing an array of the wrapper type, or an empty Optional if the input array is null
+     * @throws IllegalArgumentException if the input array is not an array of primitives or the wrapper type
+     * is not a primitive wrapper class
+     */
+    public static <T> Optional<T[]> primitiveToObjectArrayOrEmpty(@Nullable Object primitiveArray, Class<T> wrapperType) {
+        if (isNull(primitiveArray)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(primitiveToObjectArray(primitiveArray, wrapperType));
+    }
+
+	/**
+     * Convert an array of primitives to an array of the corresponding wrapper type.
+     *
+	 * @param primitiveArray an array of primitives
+     * @param wrapperType the wrapper type of the primitive type
+	 * @param <T> the wrapper type corresponding to the input array's primitive type
+	 * @return an array of the wrapper type
+     * @throws IllegalArgumentException if the input array is null or is not an array of primitives or the wrapper type
+     * is not a primitive wrapper class
+     * @implNote The internal logic is not pretty, but I cannot find an existing utility that does this (e.g. in
+     * Apache Commons or Google Guava). Apache Commons Lang's {@code ArrayUtils} is used internally to convert
+     * primitive arrays, but because of needing to handle all Java primitive types, I can't think of a cleaner way to
+     * do this other than a conditional covering all eight primitive types.
+	 */
+    @SuppressWarnings({"unchecked"})
+	public static <T> T[] primitiveToObjectArray(Object primitiveArray, Class<T> wrapperType) {
+        checkArgumentNotNull(primitiveArray, "primitiveArray must be not be null");
+        checkArgumentNotNull(wrapperType, "wrapperType must not be null");
+        checkArgument(isPrimitiveWrapper(wrapperType), "wrapperType must be a primitive wrapper type");
+
+        var arrayClass = primitiveArray.getClass();
+	    var componentType = arrayClass.getComponentType();
+	    checkArgument(arrayClass.isArray() && componentType.isPrimitive(),
+	            "primitiveArray must be an array of a primitive type");
+
+        if (componentType.equals(Boolean.TYPE)) {
+            var primitiveBooleanArray = (boolean[]) primitiveArray;
+            return (T[]) ArrayUtils.toObject(primitiveBooleanArray);
+        } else if (componentType.equals(Byte.TYPE)) {
+            var primitiveByteArray = (byte[]) primitiveArray;
+            return (T[]) ArrayUtils.toObject(primitiveByteArray);
+        } else if (componentType.equals(Character.TYPE)) {
+            var primitiveCharArray = (char[]) primitiveArray;
+            return (T[]) ArrayUtils.toObject(primitiveCharArray);
+        } else if (componentType.equals(Double.TYPE)) {
+            var primitiveDoubleArray = (double[]) primitiveArray;
+            return (T[]) ArrayUtils.toObject(primitiveDoubleArray);
+        } else if (componentType.equals(Float.TYPE)) {
+            var primitiveFloatArray = (float[]) primitiveArray;
+            return (T[]) ArrayUtils.toObject(primitiveFloatArray);
+        } else if (componentType.equals(Integer.TYPE)) {
+            var primitiveIntArray = (int[]) primitiveArray;
+            return (T[]) ArrayUtils.toObject(primitiveIntArray);
+        } else if (componentType.equals(Long.TYPE)) {
+            var primitiveLongArray = (long[]) primitiveArray;
+            return (T[]) ArrayUtils.toObject(primitiveLongArray);
+        }
+
+        // it should be a short[] since we've checked the other seven primitive types above; this should
+        // never throw unless a new primitive type is added (exceedingly unlikely) or the above code is
+        // modified such that it doesn't properly check the component type, or doesn't handle all primtive
+        // types, etc. In short, only a programming error.
+        checkState(primitiveArray instanceof short[],
+                "expected array to be short[] since it is not any other primitive type, but was: %s",
+                componentType);
+
+        var primitiveShortArray = (short[]) primitiveArray;
+        return  (T[]) ArrayUtils.toObject(primitiveShortArray);
+	}
 }

--- a/src/main/java/org/kiwiproject/beta/jdbc/KiwiJdbc2.java
+++ b/src/main/java/org/kiwiproject/beta/jdbc/KiwiJdbc2.java
@@ -5,13 +5,9 @@ import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.isNull;
 
 import com.google.common.annotations.Beta;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-
 import lombok.experimental.UtilityClass;
-
-import org.apache.commons.lang3.ArrayUtils;
 import org.kiwiproject.beta.collect.KiwiArrays2;
 
 import java.sql.ResultSet;
@@ -204,7 +200,7 @@ public class KiwiJdbc2 {
         checkIsArray(clazz, columnLabel);
 
         if (clazz.getComponentType().isPrimitive()) {
-            return primitiveToObjectArray(array);
+            return KiwiArrays2.primitiveToObjectArray(array, type);
         }
 
         return (T[]) array;
@@ -212,56 +208,5 @@ public class KiwiJdbc2 {
 
     private static void checkIsArray(Class<?> clazz, String columnLabel) {
         checkState(clazz.isArray(), "expected an array in column '%s' but found: %s", columnLabel, clazz);
-    }
-
-    // TODO: Consider moving this to KiwiArrays2; additional considerations such as what to do for null input?
-    @VisibleForTesting
-    static <T> T[] primitiveToObjectArray(Object primitiveArray) {
-        var arrayClass = primitiveArray.getClass();
-        var componentType = arrayClass.getComponentType();
-        checkArgument(arrayClass.isArray() && componentType.isPrimitive(),
-                "primitiveArray must be an array of a primitive type");
-
-        return primitiveToObjectArray(primitiveArray, componentType);
-    }
-
-    /**
-     * @implNote This is not pretty, but I cannot find an existing utility that does this (e.g. in Apache Commons
-     * or Google Guava), and because of needing to handle all Java primitive types, I can't think of a cleaner way to
-     * do this, even though this isn't exactly what I would call clean code...
-     */
-    @SuppressWarnings({"unchecked"})
-    @VisibleForTesting
-    static <T> T[] primitiveToObjectArray(Object primitiveArray, Class<?> componentType) {
-        if (componentType.equals(Boolean.TYPE)) {
-            var primitiveBooleanArray = (boolean[]) primitiveArray;
-            return (T[]) ArrayUtils.toObject(primitiveBooleanArray);
-        } else if (componentType.equals(Byte.TYPE)) {
-            var primitiveByteArray = (byte[]) primitiveArray;
-            return (T[]) ArrayUtils.toObject(primitiveByteArray);
-        } else if (componentType.equals(Character.TYPE)) {
-            var primitiveCharArray = (char[]) primitiveArray;
-            return (T[]) ArrayUtils.toObject(primitiveCharArray);
-        } else if (componentType.equals(Double.TYPE)) {
-            var primitiveDoubleArray = (double[]) primitiveArray;
-            return (T[]) ArrayUtils.toObject(primitiveDoubleArray);
-        } else if (componentType.equals(Float.TYPE)) {
-            var primitiveFloatArray = (float[]) primitiveArray;
-            return (T[]) ArrayUtils.toObject(primitiveFloatArray);
-        } else if (componentType.equals(Integer.TYPE)) {
-            var primitiveIntArray = (int[]) primitiveArray;
-            return (T[]) ArrayUtils.toObject(primitiveIntArray);
-        } else if (componentType.equals(Long.TYPE)) {
-            var primitiveLongArray = (long[]) primitiveArray;
-            return (T[]) ArrayUtils.toObject(primitiveLongArray);
-        }
-
-        // it should be a short[] since we've checked the other seven primitive types above
-        checkState(primitiveArray instanceof short[],
-                "expected array to be short[] since it is not any other primitive type, but was: %s",
-                componentType);
-
-        var primitiveShortArray = (short[]) primitiveArray;
-        return  (T[]) ArrayUtils.toObject(primitiveShortArray);
     }
 }

--- a/src/test/java/org/kiwiproject/beta/collect/KiwiArrays2Test.java
+++ b/src/test/java/org/kiwiproject/beta/collect/KiwiArrays2Test.java
@@ -3,13 +3,15 @@ package org.kiwiproject.beta.collect;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
-
+import java.util.Optional;
 import java.util.stream.Stream;
 
 @DisplayName("KiwiArrays2")
@@ -94,5 +96,177 @@ class KiwiArrays2Test {
                 Arguments.of(Character.class, -5),
                 Arguments.of(String.class, -42)
         );
+    }
+
+    @Nested
+    class PrimitiveToObjectArray {
+
+        @Test
+        void shouldThrowIllegalArgument_WhenPrimitiveArrayArgumentIsNull() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> KiwiArrays2.primitiveToObjectArray(null, Character.class))
+                    .withMessage("primitiveArray must be not be null");
+        }
+
+        @Test
+        void shouldThrowIllegalArgument_WhenWrapperTypeArgumentIsNull() {
+            var array = new byte[] {};
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> KiwiArrays2.primitiveToObjectArray(array, null))
+                    .withMessage("wrapperType must not be null");
+        }
+
+        @Test
+        void shouldThrowIllegalArgument_WhenWrapperTypeArgumentIsNotPrimitiveWrapperType() {
+            var array = new byte[] {};
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> KiwiArrays2.primitiveToObjectArray(array, String.class))
+                    .withMessage("wrapperType must be a primitive wrapper type");
+        }
+
+        @Test
+        void shouldThrowIllegalArgument_WhenPrimitiveArrayArgumentIsNotAnArray() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> KiwiArrays2.primitiveToObjectArray("this is not an array", Byte.class))
+                    .withMessage("primitiveArray must be an array of a primitive type");
+        }
+
+        @Test
+        void shouldThrowIllegalArgument_WhenPrimitiveArrayArgumentIsNotAnArrayOfPrimitives() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> KiwiArrays2.primitiveToObjectArray(new Integer[] { 42, 84}, Integer.class))
+                    .withMessage("primitiveArray must be an array of a primitive type");
+        }
+
+        @Test
+        void shouldConvert_PrimitiveBooleanArrays() {
+            var values = new boolean[] { true, true, false, true, false };
+
+            var booleanObjArray = KiwiArrays2.primitiveToObjectArray(values, Boolean.class);
+
+            Boolean[] expectedValues = ArrayUtils.toObject(values);
+            assertThat(booleanObjArray).isEqualTo(expectedValues);
+        }
+
+        @Test
+        void shouldConvert_PrimitiveByteArrays() {
+            var values = new byte[] { 1, 4, 0, 3, 2 };
+
+            var byteObjArray = KiwiArrays2.primitiveToObjectArray(values, Byte.class);
+
+            Byte[] expectedValues = ArrayUtils.toObject(values);
+            assertThat(byteObjArray).isEqualTo(expectedValues);
+        }
+
+        @Test
+        void shouldConvert_PrimitiveCharArrays() {
+            var values = new char[] { 'a', 'd', 'c', 'a' };
+
+            var characterObjArray = KiwiArrays2.primitiveToObjectArray(values, Character.class);
+
+            Character[] expectedValues = ArrayUtils.toObject(values);
+            assertThat(characterObjArray).isEqualTo(expectedValues);
+        }
+
+        @Test
+        void shouldConvert_PrimitiveDoubleArrays() {
+            var values = new double[] { 42.0, 342.0, 142.0, 42.0, 84.0 };
+
+            var doubleObjArray = KiwiArrays2.primitiveToObjectArray(values, Double.class);
+
+            Double[] expectedValues = ArrayUtils.toObject(values);
+            assertThat(doubleObjArray).isEqualTo(expectedValues);
+        }
+
+        @Test
+        void shouldConvert_PrimitiveFloatArrays() {
+            var values = new float[] { 42.0F, 342.0F, 142.0F, 42.0F, 84.0F };
+
+            var floatObjArray = KiwiArrays2.primitiveToObjectArray(values, Float.class);
+
+            Float[] expectedValues = ArrayUtils.toObject(values);
+            assertThat(floatObjArray).isEqualTo(expectedValues);
+        }
+
+        @Test
+        void shouldConvert_PrimitiveIntArrays() {
+            var values = new int[] { 42, 342, 142, 42, 84 };
+
+            var integerObjArray = KiwiArrays2.primitiveToObjectArray(values, Integer.class);
+
+            Integer[] expectedValues = ArrayUtils.toObject(values);
+            assertThat(integerObjArray).isEqualTo(expectedValues);
+        }
+
+        @Test
+        void shouldConvert_PrimitiveLongArrays() {
+            var values = new long[] { 42L, 342L, 142L, 42L, 84L };
+
+            var longObjArray = KiwiArrays2.primitiveToObjectArray(values, Long.class);
+
+            Long[] expectedValues = ArrayUtils.toObject(values);
+            assertThat(longObjArray).isEqualTo(expectedValues);
+        }
+
+        @Test
+        void shouldConvert_PrimitiveShortArrays() {
+            var values = new short[] { 42, 342, 142, 42, 84 };
+
+            var shortObjArray = KiwiArrays2.primitiveToObjectArray(values, Short.class);
+
+            Short[] expectedValues = ArrayUtils.toObject(values);
+            assertThat(shortObjArray).isEqualTo(expectedValues);
+        }
+
+        @Test
+        void shouldConvertEmptyArrays() {
+            var values = new int[0];
+
+            var integerObjArray = KiwiArrays2.primitiveToObjectArray(values, Integer.class);
+
+            assertThat(integerObjArray).isEmpty();
+        }
+    }
+
+    @Nested
+    class PrimitiveToObjectArrayOrNull {
+
+        @Test
+        void shouldReturnNull_WhenArgumentIsNull() {
+            byte[] bytes = null;
+            Byte[] result = KiwiArrays2.primitiveToObjectArrayOrNull(bytes, Byte.class);
+            assertThat(result).isNull();
+        }
+
+        @Test
+        void shouldConvertToObjectArray() {
+            var values = new long[] { 42L, 342L, 142L, 42L, 84L };
+
+            var longObjectArray = KiwiArrays2.primitiveToObjectArrayOrNull(values, Long.class);
+
+            Long[] expectedValues = ArrayUtils.toObject(values);
+            assertThat(longObjectArray).isEqualTo(expectedValues);
+        }
+    }
+
+    @Nested
+    class PrimitiveToObjectArrayOrEmpty {
+
+        @Test
+        void shouldReturnEmptyOptional_WhenArgumentIsNull() {
+            byte[] bytes = null;
+            Optional<Byte[]> result = KiwiArrays2.primitiveToObjectArrayOrEmpty(bytes, Byte.class);
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void shouldConvertToObjectArray() {
+            var values = new int[] { 42, 342, 142, 42, 84 };
+
+            var integerObjectArrayOpt = KiwiArrays2.primitiveToObjectArrayOrEmpty(values, Integer.class);
+
+            Integer[] expectedValues = ArrayUtils.toObject(values);
+            assertThat(integerObjectArrayOpt).contains(expectedValues);
+        }
     }
 }

--- a/src/test/java/org/kiwiproject/beta/jdbc/KiwiJdbc2Test.java
+++ b/src/test/java/org/kiwiproject/beta/jdbc/KiwiJdbc2Test.java
@@ -420,30 +420,4 @@ public class KiwiJdbc2Test {
         when(array.getArray()).thenReturn(actualArray);
         return array;
     }
-
-    @Nested
-    class PrimitiveToObjectArray {
-
-        @Test
-        void shouldThrowIllegalArgument_WhenArgumentIsNotAnArray() {
-            assertThatIllegalArgumentException()
-                    .isThrownBy(() -> KiwiJdbc2.primitiveToObjectArray("this is not an array"))
-                    .withMessage("primitiveArray must be an array of a primitive type");
-        }
-
-        @Test
-        void shouldThrowIllegalArgument_WhenArgumentIsNotAnArrayOfPrimitives() {
-            assertThatIllegalArgumentException()
-                    .isThrownBy(() -> KiwiJdbc2.primitiveToObjectArray(new Integer[] { 42, 84}))
-                    .withMessage("primitiveArray must be an array of a primitive type");
-        }
-
-        @Test
-        void shouldThrowIllegalState_WhenComponentTypeIsNotPrimitive() {
-            var ints = new int[] { 24, 42, 84 };
-            assertThatIllegalStateException()
-                    .isThrownBy(() -> KiwiJdbc2.primitiveToObjectArray(ints, String.class))
-                    .withMessage("expected array to be short[] since it is not any other primitive type, but was: class java.lang.String");
-        }
-    }
 }


### PR DESCRIPTION
* Move the primitive to array conversion method from KiwiJdbc2 into KiwiArrays2. To facilitate proper type inference, added a Class argument for the generic type.
* Add variants that return null and Optional when given a null array

Closes #294