### PR TITLE
Add media type utilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
         <!-- Versions for required/provided dependencies -->
 
         <camel.version>3.21.0</camel.version>
+        <jakarta.ws.rs-api>2.1.6</jakarta.ws.rs-api>
         <jakarta.xml.soap-api.version>1.4.2</jakarta.xml.soap-api.version>
         <jakarta.xml.ws-api.version>2.3.3</jakarta.xml.ws-api.version>
         <kiwi.version>2.6.0</kiwi.version>
@@ -125,6 +126,13 @@
         </dependency>
 
         <!-- provided dependencies -->
+
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>${jakarta.ws.rs-api}</version>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -263,6 +271,12 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-common</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/org/kiwiproject/beta/net/KiwiMediaTypes.java
+++ b/src/main/java/org/kiwiproject/beta/net/KiwiMediaTypes.java
@@ -1,0 +1,155 @@
+package org.kiwiproject.beta.net;
+
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotBlank;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
+import static org.kiwiproject.base.KiwiStrings.f;
+
+import com.google.common.annotations.Beta;
+import com.google.common.net.MediaType;
+
+import lombok.experimental.UtilityClass;
+
+/**
+ * Some utilities for working with <a href="https://en.wikipedia.org/wiki/Media_type">media types</a>.
+ * <p>
+ * Google Guava contains the <a href="https://javadoc.io/doc/com.google.guava/guava/latest/com/google/common/net/MediaType.html">MediaType</a>
+ * class which represents an Internet Media Type. It contains some useful methods, but not some (what we think are)
+ * basic utilities such as the ability to check if a media type is XML. Both {@code text/xml} and
+ * {@code application/xml} represent XML documents, so checking whether a media type is XML should take this into
+ * account. But the Guava {@code MediaType#is} method doesn't permit comparing like this when the type is different
+ * but the subtype is the same.
+ * <p>
+ * The Jakarta RS <a href="https://javadoc.io/doc/jakarta.ws.rs/jakarta.ws.rs-api/latest/jakarta.ws.rs/jakarta/ws/rs/core/MediaType.html">MediaType</a>
+ * is also useful, but its {@code equals} method unfortunately compares type, subtype, <em>and parameters</em> so
+ * you cannot use it to check if a media type such as "text/xml; charset=utf-8" equals the "text/xml" media type,
+ * since it will include the charset parameter in the comparison and return false.
+ *
+ * @implNote Internally this uses Guava's {@code MediaType} to parse String media types.
+ */
+@UtilityClass
+@Beta
+public class KiwiMediaTypes {
+
+    private static final String APPLICATION_TYPE = "application";
+    private static final String TEXT_TYPE = "text";
+    private static final String JSON_SUBTYPE = "json";
+    private static final String XML_SUBTYPE = "xml";
+
+    /**
+     * Checks if media type is "application/xml" or "text/xml", ignoring parameters such that
+     * "text/xml; charset=utf-8" is considered XML.
+     * <p>
+     * To use this method, the jakarta.ws.rs:jakarta.ws.rs-api dependency must be present.
+     *
+     * @param mediaType the media type to check
+     * @return true if the media type is an XML type ignoring any parameters, otherwise false
+     * @implNote This method concatenates the type and subtype of the MediaType instead of
+     * using the toString method, because the MediaType#toString requires a Jakarta RS implementation
+     * in order to create a RuntimeDelegate. Presumably if this method is used, the implementation
+     * is available, but just in case it isn't this manually creates the media type string using
+     * the type and subtype, which are just fields in MediaType and don't need a Jakarta RS
+     * implementation to be available.
+     */
+    public static boolean isXml(javax.ws.rs.core.MediaType mediaType) {
+        checkArgumentNotNull(mediaType, "mediaType must not be null");
+        return isXml(toStringWithOnlyTypeAndSubtype(mediaType));
+    }
+
+    /**
+     * Checks if media type is "application/xml" or "text/xml", ignoring parameters such that
+     * "text/xml; charset=utf-8" is considered XML.
+     *
+     * @param mediaType the media type to check
+     * @return true if the media type is an XML type ignoring any parameters, otherwise false
+     */
+    public static boolean isXml(String mediaType) {
+        checkMediaTypeNotBlank(mediaType);
+        var parsedType = MediaType.parse(mediaType);
+        var type = parsedType.type();
+        var subtype = parsedType.subtype();
+        return (TEXT_TYPE.equals(type) || APPLICATION_TYPE.equals(type)) && XML_SUBTYPE.equals(subtype);
+    }
+
+    /**
+     * Checks if media type is "application/json", ignoring parameters such that "application/json; charset=utf-8"
+     * is considered JSON.
+     * <p>
+     * To use this method, the jakarta.ws.rs:jakarta.ws.rs-api dependency must be present.
+     *
+     * @param mediaType the media type to check
+     * @return true if the media type is JSON ignoring any parameters, otherwise false
+     * @implNote This method concatenates the type and subtype of the MediaType instead of
+     * using the toString method, because the MediaType#toString requires a Jakarta RS implementation
+     * in order to create a RuntimeDelegate. Presumably if this method is used, the implementation
+     * is available, but just in case it isn't this manually creates the media type string using
+     * the type and subtype, which are just fields in MediaType and don't need a Jakarta RS
+     * implementation to be available.
+     */
+    public static boolean isJson(javax.ws.rs.core.MediaType mediaType) {
+        checkArgumentNotNull(mediaType, "mediaType must not be null");
+        return isJson(toStringWithOnlyTypeAndSubtype(mediaType));
+    }
+
+    /**
+     * Get the string value of the given MediaType with only the type/subtype.
+     *
+     * @implNote This method concatenates the type and subtype of the MediaType because the
+     * MediaType#toString requires a Jakarta RS implementation in order to create a RuntimeDelegate
+     * which is then used to convert to a String. Presumably if this method is used, the implementation
+     * is available, but just in case it isn't, this method manually creates the media type string using
+     * the type and subtype, since they are just fields in MediaType and don't need a Jakarta RS
+     * implementation to be available.
+     */
+    private static String toStringWithOnlyTypeAndSubtype(javax.ws.rs.core.MediaType mediaType) {
+        return f("{}/{}", mediaType.getType(), mediaType.getSubtype());
+    }
+
+    /**
+     * Checks if media type is "application/json", ignoring parameters such that "application/json; charset=utf-8"
+     * is considered JSON.
+     *
+     * @param mediaType the media type to check
+     * @return true if the media type is JSON ignoring any parameters, otherwise false
+     */
+    public static boolean isJson(String mediaType) {
+        checkMediaTypeNotBlank(mediaType);
+        var parsedType = MediaType.parse(mediaType);
+        var type = parsedType.type();
+        var subtype = parsedType.subtype();
+        return APPLICATION_TYPE.equals(type) && JSON_SUBTYPE.equals(subtype);
+    }
+
+    /**
+     * Checks if the given media type has a type that matches the given value.
+     *
+     * @param mediaType the media type to check
+     * @param typeToMatch the type to match
+     * @return true if the types match, otherwise false
+     */
+    public static boolean matchesType(String mediaType, String typeToMatch) {
+        checkMediaTypeNotBlank(mediaType);
+        checkArgumentNotBlank(typeToMatch, "typeToMatch must not be blank");
+        var parsedType = MediaType.parse(mediaType);
+        var type = parsedType.type();
+        return typeToMatch.equals(type);
+    }
+
+    /**
+     * Checks if the given media type has a type that matches the given value.
+     *
+     * @param mediaType the media type to check
+     * @param subtypeToMatch the subtype to match
+     * @return true if the subtypes match, otherwise false
+     */
+    public static boolean matchesSubtype(String mediaType, String subtypeToMatch) {
+        checkMediaTypeNotBlank(mediaType);
+        checkArgumentNotBlank(subtypeToMatch, "subtypeToMatch must not be blank");
+        var parsedType = MediaType.parse(mediaType);
+        var subtype = parsedType.subtype();
+        return subtypeToMatch.equals(subtype);
+    }
+
+    private static void checkMediaTypeNotBlank(String mediaType) {
+        checkArgumentNotBlank(mediaType, "mediaType must not be blank");
+    }
+}

--- a/src/test/java/org/kiwiproject/beta/net/KiwiMediaTypesTest.java
+++ b/src/test/java/org/kiwiproject/beta/net/KiwiMediaTypesTest.java
@@ -1,0 +1,211 @@
+package org.kiwiproject.beta.net;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.kiwiproject.test.junit.jupiter.params.provider.AsciiOnlyBlankStringSource;
+
+import javax.ws.rs.core.MediaType;
+
+@DisplayName("KiwiMediaTypes")
+class KiwiMediaTypesTest {
+
+    @Nested
+    class IsXml {
+
+        @ParameterizedTest
+        @AsciiOnlyBlankStringSource
+        void shouldNotAllowBlankMediaType(String value) {
+            assertThatIllegalArgumentException().isThrownBy(() -> KiwiMediaTypes.isXml(value));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "application/xml",
+            "application/xml; charset=utf-8",
+            "text/xml",
+            "text/xml; charset=utf-8",
+            "text/xml; charset=ISO-8859-1"
+        })
+        void shouldBeTrue_WhenGivenAnAcceptableXmlType(String mediaType) {
+            assertThat(KiwiMediaTypes.isXml(mediaType)).isTrue();
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "application/json",
+            "text/plain",
+            "application/octet-stream",
+            "application/x-www-form-urlencoded",
+            "text/html",
+            "image/png"
+        })
+        void shouldBeFalse_WhenNotAnXmlType(String mediaType) {
+            assertThat(KiwiMediaTypes.isXml(mediaType)).isFalse();
+        }
+    }
+
+    @Nested
+    class IsXmlWithJakartaMediaType {
+
+        @Test
+        void shouldNotAllowNullMediaType() {
+            assertThatIllegalArgumentException().isThrownBy(() -> KiwiMediaTypes.isXml((MediaType) null));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "application/xml",
+            "application/xml; charset=utf-8",
+            "text/xml",
+            "text/xml; charset=utf-8",
+            "text/xml; charset=ISO-8859-1"
+        })
+        void shouldBeTrue_WhenGivenAnAcceptableXmlType(String mediaType) {
+            assertThat(KiwiMediaTypes.isXml(MediaType.valueOf(mediaType))).isTrue();
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "application/json",
+            "text/plain",
+            "application/octet-stream",
+            "application/x-www-form-urlencoded",
+            "text/html",
+            "image/png"
+        })
+        void shouldBeFalse_WhenNotAnXmlType(String mediaType) {
+            assertThat(KiwiMediaTypes.isXml(MediaType.valueOf(mediaType))).isFalse();
+        }
+    }
+
+    @Nested
+    class IsJson {
+
+        @ParameterizedTest
+        @AsciiOnlyBlankStringSource
+        void shouldNotAllowBlankMediaType(String value) {
+            assertThatIllegalArgumentException().isThrownBy(() -> KiwiMediaTypes.isJson(value));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "application/json",
+            "application/json; charset=utf-8",
+            "application/json; charset=ISO-8859-1",
+        })
+        void shouldBeTrue_WhenGivenAnAcceptableJsonType(String mediaType) {
+            assertThat(KiwiMediaTypes.isJson(mediaType)).isTrue();
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "application/xml",
+            "text/css",
+            "text/html; charset=utf-8",
+            "text/xml; charset=ISO-8859-1",
+            "image/jpeg"
+        })
+        void shouldBeFalse_WhenNotJsonType(String mediaType) {
+            assertThat(KiwiMediaTypes.isJson(mediaType)).isFalse();
+        }
+    }
+
+    @Nested
+    class IsJsonWithJakartaMediaType {
+
+        @Test
+        void shouldNotAllowNullMediaType() {
+            assertThatIllegalArgumentException().isThrownBy(() -> KiwiMediaTypes.isJson((MediaType) null));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "application/json",
+            "application/json; charset=utf-8",
+            "application/json; charset=ISO-8859-1",
+        })
+        void shouldBeTrue_WhenGivenAnAcceptableJsonType(String mediaType) {
+            assertThat(KiwiMediaTypes.isJson(MediaType.valueOf(mediaType))).isTrue();
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "application/xml",
+            "text/css",
+            "text/html; charset=utf-8",
+            "text/xml; charset=ISO-8859-1",
+            "image/jpeg"
+        })
+        void shouldBeFalse_WhenNotJsonType(String mediaType) {
+            assertThat(KiwiMediaTypes.isJson(MediaType.valueOf(mediaType))).isFalse();
+        }
+    }
+
+    @Nested
+    class MatchesType {
+
+        @ParameterizedTest
+        @AsciiOnlyBlankStringSource
+        void shouldNotAllowBlankMediaType(String value) {
+            assertThatIllegalArgumentException().isThrownBy(() -> KiwiMediaTypes.matchesType(value, "text"));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "text/html",
+            "text/plain",
+            "text/css",
+            "text/xml; charset=utf-8"
+        })
+        void shouldBeTrue_WhenTypesMatch(String mediaType) {
+            assertThat(KiwiMediaTypes.matchesType(mediaType, "text")).isTrue();
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "application/json",
+            "application/json; charset=utf-8",
+            "image/png",
+            "application/octet-stream",
+        })
+        void shouldBeFalse_WhenTypesDoNotMatch(String mediaType) {
+            assertThat(KiwiMediaTypes.matchesType(mediaType, "text")).isFalse();
+        }
+    }
+
+    @Nested
+    class MatchesSubtype {
+
+        @ParameterizedTest
+        @AsciiOnlyBlankStringSource
+        void shouldNotAllowBlankMediaType(String value) {
+            assertThatIllegalArgumentException().isThrownBy(() -> KiwiMediaTypes.matchesSubtype(value, "xml"));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "text/xml",
+            "application/xml",
+            "text/xml; charset=utf-8",
+        })
+        void shouldBeTrue_WhenSubtypesMatch(String mediaType) {
+            assertThat(KiwiMediaTypes.matchesSubtype(mediaType, "xml")).isTrue();
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "text/xml",
+            "application/xml",
+            "text/xml; charset=utf-8",
+        })
+        void shouldBeFalse_WhenSubtypesDoNotMatch(String mediaType) {
+            assertThat(KiwiMediaTypes.matchesSubtype(mediaType, "json")).isFalse();
+        }
+    }
+}


### PR DESCRIPTION
* Add KiwiMediaTypes utility class
* Add jakarta.ws.rs-api as a provided dependency so that it is not a required transitive dependency. Only if callers use the methods that accept Jakarta RS MediaType will that dependency be needed. If they are only using Strings then the only dependency is Guava, which is already required.
* For the tests to use the Jakarta RS MediaType#valueOf method I needed to add jersey-common as a test-scope dependency because valueOf internally requires an implementation

Closes #296