### PR TITLE
Enhancements to ProcessHelpers

### DIFF
--- a/src/main/java/org/kiwiproject/beta/base/process/ProcessHelpers.java
+++ b/src/main/java/org/kiwiproject/beta/base/process/ProcessHelpers.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.kiwiproject.base.process.ProcessHelper;
 import org.kiwiproject.io.KiwiIO;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -53,6 +54,19 @@ public class ProcessHelpers {
     /**
      * Execute command with the given timeout.
      *
+     * @see #execute(ProcessHelper, List, long, TimeUnit)
+     */
+    public static ProcessResult execute(ProcessHelper processHelper,
+                                        List<String> command,
+                                        Duration timeout) {
+
+        var timeoutNanos = timeout.toNanos();
+        return execute(processHelper, command, timeoutNanos, TimeUnit.NANOSECONDS);
+    }
+
+    /**
+     * Execute command with the given timeout.
+     *
      * @implNote This uses {@link CompletableFuture} to ensure we time out even if the stdout
      * or stderr blocks, which according to the {@link Process} docs, can at least theoretically
      * happen. For example, if someone gives the command {@code ls -laR /} to list all files in
@@ -60,7 +74,7 @@ public class ProcessHelpers {
      */
     public static ProcessResult execute(ProcessHelper processHelper,
                                         List<String> command,
-                                        int timeout,
+                                        long timeout,
                                         TimeUnit timeoutUnit) {
 
         var timeoutMillis = Ints.checkedCast(timeoutUnit.toMillis(timeout));

--- a/src/test/java/org/kiwiproject/beta/base/process/ProcessHelpersTest.java
+++ b/src/test/java/org/kiwiproject/beta/base/process/ProcessHelpersTest.java
@@ -15,6 +15,7 @@ import org.kiwiproject.base.process.Processes;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -74,7 +75,7 @@ class ProcessHelpersTest {
         void shouldHandleTimeoutsGracefully_WhenProcessTakesLongerThanTimeout() {
             // This should take WAY more than 10 milliseconds
             var command = List.of("ls", "-lAR", "/");
-            var processResult = ProcessHelpers.execute(processHelper, command, 10, TimeUnit.MILLISECONDS);
+            var processResult = ProcessHelpers.execute(processHelper, command, Duration.ofMillis(10));
 
             assertThat(processResult.isTimedOut()).isTrue();
             assertThat(processResult.getTimeoutThresholdMillis()).isEqualTo(10);
@@ -91,7 +92,7 @@ class ProcessHelpersTest {
         void shouldHandleTimeoutsGracefully_WhenProcessNeverExits() {
             // Executing cat with no args causes it to wait indefinitely for stdin
             var command = List.of("cat");
-            var processResult = ProcessHelpers.execute(processHelper, command, 100, TimeUnit.MILLISECONDS);
+            var processResult = ProcessHelpers.execute(processHelper, command, Duration.ofMillis(100));
 
             assertThat(processResult.isTimedOut()).isTrue();
             assertThat(processResult.getTimeoutThresholdMillis()).isEqualTo(100);


### PR DESCRIPTION
* The timeout argument in ProcessResult#execute should be a long
* Overload ProcessResult#execute to allow timeout as a java.time.Duration

Closes  #325
Closes  #326