### PR TITLE
Update X.509 certificate request attribute name in KiwiServletRequests

### DIFF
--- a/src/main/java/org/kiwiproject/beta/servlet/KiwiServletRequests.java
+++ b/src/main/java/org/kiwiproject/beta/servlet/KiwiServletRequests.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 @Beta
 public class KiwiServletRequests {
 
-    public static final String X509_CERTIFICATE_ATTRIBUTE = "javax.servlet.request.X509Certificate";
+    public static final String X509_CERTIFICATE_ATTRIBUTE = "jakarta.servlet.request.X509Certificate";
 
     public static boolean hasCertificates(ServletRequest request) {
         return nonNull(request.getAttribute(X509_CERTIFICATE_ATTRIBUTE));


### PR DESCRIPTION
The X.509 certificate attribute name used in the KiwiServletRequests class has been changed from "javax.servlet.request.X509Certificate" to "jakarta.servlet.request.X509Certificate". This change was necessary to comply with change in the Servlet API during the transition from Java EE to Jakarta EE.

Fixes #356