### PR TITLE
Increase timeouts in ProcessHelpersTest and make them RetryingTests

### DIFF
--- a/src/main/java/org/kiwiproject/beta/base/process/ProcessHelpers.java
+++ b/src/main/java/org/kiwiproject/beta/base/process/ProcessHelpers.java
@@ -84,6 +84,7 @@ public class ProcessHelpers {
 
     private static ProcessResult tryExecute(ProcessHelper processHelper, List<String> command, int timeoutMillis) {
         try {
+            LOG.trace("Executing command with timeout of {} millis: {}", timeoutMillis, command);
             return CompletableFuture
                     .supplyAsync(() -> executeSync(processHelper, command, timeoutMillis))
                     .get(timeoutMillis, TimeUnit.MILLISECONDS);

--- a/src/test/java/org/kiwiproject/beta/base/process/ProcessHelpersTest.java
+++ b/src/test/java/org/kiwiproject/beta/base/process/ProcessHelpersTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.RetryingTest;
 import org.kiwiproject.base.process.ProcessHelper;
 import org.kiwiproject.base.process.Processes;
 
@@ -40,7 +41,7 @@ class ProcessHelpersTest {
             processHelper = new ProcessHelper();
         }
 
-        @Test
+        @RetryingTest(3)
         void shouldReadStdOut() {
             var command = List.of("echo", "foo bar baz");
             var processResult = ProcessHelpers.execute(processHelper, command, 10_000_000, TimeUnit.MICROSECONDS);
@@ -56,7 +57,7 @@ class ProcessHelpersTest {
             assertThat(processResult.getError()).isEmpty();
         }
 
-        @Test
+        @RetryingTest(3)
         void shouldReadStdErr() {
             var processResult = ProcessHelpers.execute(processHelper, List.of("cat", "foo"));
 
@@ -105,7 +106,7 @@ class ProcessHelpersTest {
             assertThat(processResult.getError()).containsInstanceOf(TimeoutException.class);
         }
 
-        @Test
+        @RetryingTest(3)
         void shouldHandleProcessExceptionsGracefully() {
             var processHelperSpy = spy(new ProcessHelper());
 

--- a/src/test/java/org/kiwiproject/beta/base/process/ProcessHelpersTest.java
+++ b/src/test/java/org/kiwiproject/beta/base/process/ProcessHelpersTest.java
@@ -46,7 +46,7 @@ class ProcessHelpersTest {
             var processResult = ProcessHelpers.execute(processHelper, command, 10_000_000, TimeUnit.MICROSECONDS);
 
             assertThat(processResult.isTimedOut()).describedAs("timed out after 10 seconds").isFalse();
-            assertThat(processResult.getTimeoutThresholdMillis()).isEqualTo(1000);
+            assertThat(processResult.getTimeoutThresholdMillis()).isEqualTo(10_000);
             assertThat(processResult.getExitCode()).hasValue(0);
             assertThat(processResult.isSuccessfulExit()).isTrue();
             assertThat(processResult.isNotSuccessfulExit()).isFalse();

--- a/src/test/java/org/kiwiproject/beta/base/process/ProcessHelpersTest.java
+++ b/src/test/java/org/kiwiproject/beta/base/process/ProcessHelpersTest.java
@@ -45,7 +45,7 @@ class ProcessHelpersTest {
             var command = List.of("echo", "foo bar baz");
             var processResult = ProcessHelpers.execute(processHelper, command, 1_000_000, TimeUnit.MICROSECONDS);
 
-            assertThat(processResult.isTimedOut()).isFalse();
+            assertThat(processResult.isTimedOut()).describedAs("timed out").isFalse();
             assertThat(processResult.getTimeoutThresholdMillis()).isEqualTo(1000);
             assertThat(processResult.getExitCode()).hasValue(0);
             assertThat(processResult.isSuccessfulExit()).isTrue();
@@ -60,7 +60,7 @@ class ProcessHelpersTest {
         void shouldReadStdErr() {
             var processResult = ProcessHelpers.execute(processHelper, List.of("cat", "foo"));
 
-            assertThat(processResult.isTimedOut()).isFalse();
+            assertThat(processResult.isTimedOut()).describedAs("timed out").isFalse();
             assertThat(processResult.getTimeoutThresholdMillis()).isEqualTo(5000);  // default timeout
             assertThat(processResult.getExitCode()).hasValue(1);
             assertThat(processResult.isSuccessfulExit()).isFalse();
@@ -119,10 +119,10 @@ class ProcessHelpersTest {
 
             // Trying to run a command that does not exist results in IOException
             var command = List.of("some", "command");
-            var processResult = ProcessHelpers.execute(processHelperSpy, command, 250, TimeUnit.MILLISECONDS);
+            var processResult = ProcessHelpers.execute(processHelperSpy, command, 1_500, TimeUnit.MILLISECONDS);
 
-            assertThat(processResult.isTimedOut()).isFalse();
-            assertThat(processResult.getTimeoutThresholdMillis()).isEqualTo(250);
+            assertThat(processResult.isTimedOut()).describedAs("timed out").isFalse();
+            assertThat(processResult.getTimeoutThresholdMillis()).isEqualTo(1_500);
             assertThat(processResult.getExitCode()).isEmpty();
             assertThat(processResult.isSuccessfulExit()).isFalse();
             assertThat(processResult.isNotSuccessfulExit()).isTrue();

--- a/src/test/java/org/kiwiproject/beta/base/process/ProcessHelpersTest.java
+++ b/src/test/java/org/kiwiproject/beta/base/process/ProcessHelpersTest.java
@@ -44,10 +44,10 @@ class ProcessHelpersTest {
         @RetryingTest(3)
         void shouldReadStdOut() {
             var command = List.of("echo", "foo bar baz");
-            var processResult = ProcessHelpers.execute(processHelper, command, 10_000_000, TimeUnit.MICROSECONDS);
+            var processResult = ProcessHelpers.execute(processHelper, command, 1_000_000, TimeUnit.MICROSECONDS);
 
-            assertThat(processResult.isTimedOut()).describedAs("timed out after 10 seconds").isFalse();
-            assertThat(processResult.getTimeoutThresholdMillis()).isEqualTo(10_000);
+            assertThat(processResult.isTimedOut()).describedAs("timed out after 1 second").isFalse();
+            assertThat(processResult.getTimeoutThresholdMillis()).isEqualTo(1000);
             assertThat(processResult.getExitCode()).hasValue(0);
             assertThat(processResult.isSuccessfulExit()).isTrue();
             assertThat(processResult.isNotSuccessfulExit()).isFalse();
@@ -120,10 +120,10 @@ class ProcessHelpersTest {
 
             // Trying to run a command that does not exist results in IOException
             var command = List.of("some", "command");
-            var processResult = ProcessHelpers.execute(processHelperSpy, command, 7_500, TimeUnit.MILLISECONDS);
+            var processResult = ProcessHelpers.execute(processHelperSpy, command, 1_500, TimeUnit.MILLISECONDS);
 
-            assertThat(processResult.isTimedOut()).describedAs("timed out after 7.5 seconds").isFalse();
-            assertThat(processResult.getTimeoutThresholdMillis()).isEqualTo(7_500);
+            assertThat(processResult.isTimedOut()).describedAs("timed out after 1.5 seconds").isFalse();
+            assertThat(processResult.getTimeoutThresholdMillis()).isEqualTo(1_500);
             assertThat(processResult.getExitCode()).isEmpty();
             assertThat(processResult.isSuccessfulExit()).isFalse();
             assertThat(processResult.isNotSuccessfulExit()).isTrue();

--- a/src/test/java/org/kiwiproject/beta/base/process/ProcessHelpersTest.java
+++ b/src/test/java/org/kiwiproject/beta/base/process/ProcessHelpersTest.java
@@ -43,9 +43,9 @@ class ProcessHelpersTest {
         @Test
         void shouldReadStdOut() {
             var command = List.of("echo", "foo bar baz");
-            var processResult = ProcessHelpers.execute(processHelper, command, 1_000_000, TimeUnit.MICROSECONDS);
+            var processResult = ProcessHelpers.execute(processHelper, command, 10_000_000, TimeUnit.MICROSECONDS);
 
-            assertThat(processResult.isTimedOut()).describedAs("timed out").isFalse();
+            assertThat(processResult.isTimedOut()).describedAs("timed out after 10 seconds").isFalse();
             assertThat(processResult.getTimeoutThresholdMillis()).isEqualTo(1000);
             assertThat(processResult.getExitCode()).hasValue(0);
             assertThat(processResult.isSuccessfulExit()).isTrue();
@@ -60,7 +60,7 @@ class ProcessHelpersTest {
         void shouldReadStdErr() {
             var processResult = ProcessHelpers.execute(processHelper, List.of("cat", "foo"));
 
-            assertThat(processResult.isTimedOut()).describedAs("timed out").isFalse();
+            assertThat(processResult.isTimedOut()).describedAs("timed out after 5 seconds").isFalse();
             assertThat(processResult.getTimeoutThresholdMillis()).isEqualTo(5000);  // default timeout
             assertThat(processResult.getExitCode()).hasValue(1);
             assertThat(processResult.isSuccessfulExit()).isFalse();
@@ -119,10 +119,10 @@ class ProcessHelpersTest {
 
             // Trying to run a command that does not exist results in IOException
             var command = List.of("some", "command");
-            var processResult = ProcessHelpers.execute(processHelperSpy, command, 1_500, TimeUnit.MILLISECONDS);
+            var processResult = ProcessHelpers.execute(processHelperSpy, command, 7_500, TimeUnit.MILLISECONDS);
 
-            assertThat(processResult.isTimedOut()).describedAs("timed out").isFalse();
-            assertThat(processResult.getTimeoutThresholdMillis()).isEqualTo(1_500);
+            assertThat(processResult.isTimedOut()).describedAs("timed out after 7.5 seconds").isFalse();
+            assertThat(processResult.getTimeoutThresholdMillis()).isEqualTo(7_500);
             assertThat(processResult.getExitCode()).isEmpty();
             assertThat(processResult.isSuccessfulExit()).isFalse();
             assertThat(processResult.isNotSuccessfulExit()).isTrue();


### PR DESCRIPTION
* Change the three test that intermittently fail to be RetryingTests (JUnit Pioneer)
* Increase the timeout from 250 milliseconds to 1.5 seconds in ProcessHelpersTest#shouldHandleProcessExceptionsGracefully which (theoretically) should never fail, even in GitHub Actions.
* To aid in initial problem diagnosis, add a describedBy to each of the three tests where we are (more and more often) seeing timeouts where we never used to see them.
* Add a new TRACE logging statement in ProcessHelpers#tryExecute.

Closes #365