### PR TITLE
Deprecate InMemoryAppender and InMemoryAppenderAssertions for removal

### DIFF
--- a/src/main/java/org/kiwiproject/beta/test/logback/InMemoryAppender.java
+++ b/src/main/java/org/kiwiproject/beta/test/logback/InMemoryAppender.java
@@ -5,6 +5,7 @@ import static java.util.Comparator.comparing;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
 import com.google.common.annotations.Beta;
+import org.kiwiproject.base.KiwiDeprecated;
 
 import java.util.List;
 import java.util.Map;
@@ -17,8 +18,14 @@ import java.util.stream.Stream;
  * A logback appender that stores logging events in an in-memory map.
  * <p>
  * This is for testing purposes only, and is not at all intended for production use!
+ *
+ * @deprecated replaced by InMemoryAppender in
+ * <a href="https://github.com/kiwiproject/kiwi-test/">kiwi-test</a> 3.2.0
  */
 @Beta
+@Deprecated(since = "1.3.0", forRemoval = true)
+@KiwiDeprecated(replacedBy = "InMemoryAppender in kiwi-test 3.2.0")
+@SuppressWarnings("java:S1133")
 public class InMemoryAppender extends AppenderBase<ILoggingEvent> {
 
     private final AtomicInteger messageOrder;

--- a/src/main/java/org/kiwiproject/beta/test/logback/InMemoryAppenderAssertions.java
+++ b/src/main/java/org/kiwiproject/beta/test/logback/InMemoryAppenderAssertions.java
@@ -3,13 +3,20 @@ package org.kiwiproject.beta.test.logback;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import com.google.common.annotations.Beta;
 import org.assertj.core.api.Assertions;
+import org.kiwiproject.base.KiwiDeprecated;
 
 import java.util.List;
 
 /**
  * Provides AssertJ assertions for {@link InMemoryAppender}.
+ *
+ * @deprecated replaced by InMemoryAppenderAssertions in
+ * <a href="https://github.com/kiwiproject/kiwi-test/">kiwi-test</a> 3.2.0
  */
 @Beta
+@Deprecated(since = "1.3.0", forRemoval = true)
+@KiwiDeprecated(replacedBy = "InMemoryAppenderAssertions in kiwi-test 3.2.0")
+@SuppressWarnings({"removal", "java:S1133", "DeprecatedIsStillUsed"})
 public class InMemoryAppenderAssertions {
 
     private final InMemoryAppender appender;

--- a/src/test/java/org/kiwiproject/beta/slf4j/KiwiSlf4jTest.java
+++ b/src/test/java/org/kiwiproject/beta/slf4j/KiwiSlf4jTest.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 /**
  * @implNote See the loggers defined for this test in {@code src/test/resources/logback-test.xml}.
  */
+@SuppressWarnings("removal")
 @DisplayName("KiwiSlf4j")
 class KiwiSlf4jTest {
 

--- a/src/test/java/org/kiwiproject/beta/slf4j/TimestampingLoggerTest.java
+++ b/src/test/java/org/kiwiproject/beta/slf4j/TimestampingLoggerTest.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
 
+@SuppressWarnings("removal")
 @DisplayName("TimestampingLogger")
 class TimestampingLoggerTest {
 

--- a/src/test/java/org/kiwiproject/beta/test/logback/InMemoryAppenderTest.java
+++ b/src/test/java/org/kiwiproject/beta/test/logback/InMemoryAppenderTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
 
+@SuppressWarnings("removal")
 @DisplayName("InMemoryAppender")
 class InMemoryAppenderTest {
 

--- a/src/test/java/org/kiwiproject/beta/test/servlet/KiwiServletMocksTest.java
+++ b/src/test/java/org/kiwiproject/beta/test/servlet/KiwiServletMocksTest.java
@@ -27,6 +27,7 @@ class KiwiServletMocksTest {
 
         var x509Cert = x509Certs[0];
 
+        //noinspection deprecation
         var principal = x509Cert.getSubjectDN();
         assertThat(principal.getName()).isEqualTo(dn);
 

--- a/src/test/kotlin/org/kiwiproject/beta/slf4j/KiwiSlf4jExtensionsTest.kt
+++ b/src/test/kotlin/org/kiwiproject/beta/slf4j/KiwiSlf4jExtensionsTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("removal")
+
 package org.kiwiproject.beta.slf4j
 
 import org.assertj.core.api.Assertions.assertThat
@@ -15,6 +17,7 @@ import java.io.IOException
 //
 // See the loggers (which must exist) for this test in src/test/resources/logback-test.xml
 //
+@Suppress("removal")
 @DisplayName("KiwiSlf4jExtensions")
 internal class KiwiSlf4jExtensionsTest {
 


### PR DESCRIPTION
* Deprecate InMemoryAppender and InMemoryAppenderAssertions for removal, since 1.3.0. I intentionally left out the "removeAt" on the KiwiDeprecated annotations, because I don't know exactly when they will be removed.
* Suppress as many warnings within this codebase about the deprecations; since kiwi-test 3.2.0 is not yet released, I can't switch the usages yet.
* Misc: suppress usage of getSubjectDN in KiwiServletMocksTest since we need to support both at present.

Closes #367
Closes #368