### PR TITLE
Qodana: Disable Lombok Getter/Setter may be used

### DIFF
--- a/qodana.yml
+++ b/qodana.yml
@@ -2,3 +2,6 @@ version: "1.0"
 linter: jetbrains/qodana-jvm-community:latest
 profile:
   name: qodana.recommended
+exclude:
+  - name: LombokGetterMayBeUsed
+  - name: LombokSetterMayBeUsed


### PR DESCRIPTION
These inspections can be overly aggressive, and sometimes incorrect.

Plus, there are times I intentionally do
not want to use Lombok.