### PR TITLE
Add new process utilties in ProcessHelpers

### DIFF
--- a/src/main/java/org/kiwiproject/beta/base/process/ProcessHelpers.java
+++ b/src/main/java/org/kiwiproject/beta/base/process/ProcessHelpers.java
@@ -224,10 +224,7 @@ public class ProcessHelpers {
     }
 
     /**
-     * Executes a pipeline of the given commands. Each command is split on spaces.
-     * <p>
-     * <strong>Warning:</strong> The same caveats on command splitting on spaces
-     * apply to this method, as described in {@link #launchCommand(String)}.
+     * Executes a pipeline of the given commands.
      *
      * @param commands the commands in the pipeline
      * @return the <strong>last</strong> {@link Process} in the pipeline
@@ -239,11 +236,9 @@ public class ProcessHelpers {
     }
 
     /**
-     * Executes a pipeline of the given commands. Each command is split on spaces.
-     * Each command in the pipeline uses the given working directory.
+     * Executes a pipeline of the given commands.
      * <p>
-     * <strong>Warning:</strong> The same caveats on command splitting on spaces
-     * apply to this method, as described in {@link #launchCommand(String)}.
+     * Each command in the pipeline uses the given working directory.
      *
      * @param workingDirectory the working directory for each command in the pipeline
      * @param commands the commands in the pipeline
@@ -254,7 +249,7 @@ public class ProcessHelpers {
     public static Process launchPipeline(@Nullable File workingDirectory,  List<List<String>> commands) {
         checkArgumentNotEmpty(commands, "commands must not be empty");
         var procBuilders = commands.stream()
-                .filter(command -> KiwiLists.isNotNullOrEmpty(command))
+                .filter(KiwiLists::isNotNullOrEmpty)
                 .map(command -> new ProcessBuilder(command).directory(workingDirectory))
                 .toList();
 

--- a/src/main/java/org/kiwiproject/beta/base/process/ProcessHelpers.java
+++ b/src/main/java/org/kiwiproject/beta/base/process/ProcessHelpers.java
@@ -155,7 +155,7 @@ public class ProcessHelpers {
      * In other words, this method is not a command parser.
      *
      * @param command the command to execute
-     * @return the new {@link Processs}
+     * @return the new {@link Process}
      * @throws UncheckedIOException if anything goes wrong, for example if the working directory does not exist
      */
     public static Process launchCommand(String command) {
@@ -170,7 +170,7 @@ public class ProcessHelpers {
      *
      * @param workingDirectory the working directory for the command
      * @param command the command to execute
-     * @return the new {@link Processs}
+     * @return the new {@link Process}
      * @throws UncheckedIOException if anything goes wrong, for example if the working directory does not exist
      */
     public static Process launchCommand(@Nullable File workingDirectory, String command) {

--- a/src/test/java/org/kiwiproject/beta/base/process/ProcessHelpersTest.java
+++ b/src/test/java/org/kiwiproject/beta/base/process/ProcessHelpersTest.java
@@ -309,11 +309,12 @@ class ProcessHelpersTest {
         void shouldThrowUncheckedIOException_WhenInvalidWorkingDirectory() {
             var ls = List.of("ls", "-1");
             var sort = List.of("sort", "-r");
+            var pipeline = List.of(ls, sort);
 
             var dir = new File("/foo/bar/baz" + System.currentTimeMillis());
 
             assertThatExceptionOfType(UncheckedIOException.class)
-                    .isThrownBy(() -> ProcessHelpers.launchPipeline(dir, List.of(ls, sort)))
+                    .isThrownBy(() -> ProcessHelpers.launchPipeline(dir, pipeline))
                     .havingCause()
                     .isExactlyInstanceOf(IOException.class);
         }


### PR DESCRIPTION
* Add overloaded launchCommand methods which accept a String as a command, for example "ls -lart" or "echo foo bar baz". One of the overloads accepts a File argument which represents the working directory for the Process.
* Add overloaded launchPipelineCommand methods which accept a pipeline command, for example "ls -1 | sort -r | head -5". Like launchCommand, one overload accepts a File for the process working directory.
* Add overloaded launchPipeline methods which accept a List<List<String>>, with each sub-list representing a single command in the pipeline. Like the other new methods,  one overload accepts a File which is the working directory for each command in the pipeline.