### PR TITLE
Return unmodifiable collections; Sonar cleanup

### DIFF
--- a/src/main/java/org/kiwiproject/beta/base/jar/JarManifests.java
+++ b/src/main/java/org/kiwiproject/beta/base/jar/JarManifests.java
@@ -1,7 +1,7 @@
 package org.kiwiproject.beta.base.jar;
 
 import static java.util.Objects.nonNull;
-import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toUnmodifiableMap;
 import static org.kiwiproject.base.KiwiStrings.f;
 
 import com.google.common.annotations.Beta;
@@ -56,7 +56,7 @@ public class JarManifests {
         return manifest.getMainAttributes()
                 .entrySet()
                 .stream()
-                .collect(toMap(e -> String.valueOf(e.getKey()), e -> String.valueOf(e.getValue())));
+                .collect(toUnmodifiableMap(e -> String.valueOf(e.getKey()), e -> String.valueOf(e.getValue())));
     }
 
     public static Manifest getManifestOrThrow(Class<?> theClass) {

--- a/src/main/java/org/kiwiproject/beta/net/KiwiUrls2.java
+++ b/src/main/java/org/kiwiproject/beta/net/KiwiUrls2.java
@@ -1,6 +1,6 @@
 package org.kiwiproject.beta.net;
 
-import static java.util.stream.Collectors.toSet;
+import static java.util.stream.Collectors.toUnmodifiableSet;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 
 import com.google.common.annotations.Beta;
@@ -61,7 +61,7 @@ public class KiwiUrls2 {
 
         return urls.stream()
                 .map(KiwiUrls2::hostOnlyUrlFrom)
-                .collect(toSet());
+                .collect(toUnmodifiableSet());
     }
 
     /*

--- a/src/test/java/org/kiwiproject/beta/base/KiwiStrings2Test.java
+++ b/src/test/java/org/kiwiproject/beta/base/KiwiStrings2Test.java
@@ -1,6 +1,6 @@
 package org.kiwiproject.beta.base;
 
-import static java.util.stream.Collectors.toSet;
+import static java.util.stream.Collectors.toUnmodifiableSet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
@@ -156,7 +156,7 @@ class KiwiStrings2Test {
             var strings = KiwiStrings2.randomCaseVariants(input);
             assertThat(strings).hasSize(3).doesNotHaveDuplicates();
 
-            var uniqueLowerCaseStrings = strings.stream().map(String::toLowerCase).collect(toSet());
+            var uniqueLowerCaseStrings = strings.stream().map(String::toLowerCase).collect(toUnmodifiableSet());
             assertThat(uniqueLowerCaseStrings).containsExactly(input);
         }
 
@@ -204,7 +204,7 @@ class KiwiStrings2Test {
             var strings = KiwiStrings2.randomCaseVariants(input, desiredSize);
             assertThat(strings).hasSize(desiredSize).doesNotHaveDuplicates();
 
-            var uniqueLowerCaseStrings = strings.stream().map(String::toLowerCase).collect(toSet());
+            var uniqueLowerCaseStrings = strings.stream().map(String::toLowerCase).collect(toUnmodifiableSet());
             assertThat(uniqueLowerCaseStrings).containsExactly(input);
         }
 
@@ -229,7 +229,7 @@ class KiwiStrings2Test {
 
             assertThat(strings).hasSize(maximumSize).doesNotHaveDuplicates();
 
-            var uniqueLowerCaseStrings = strings.stream().map(String::toLowerCase).collect(toSet());
+            var uniqueLowerCaseStrings = strings.stream().map(String::toLowerCase).collect(toUnmodifiableSet());
             assertThat(uniqueLowerCaseStrings).containsExactly(input);
         }
 
@@ -278,7 +278,7 @@ class KiwiStrings2Test {
             var strings = KiwiStrings2.randomCaseVariants(input, desiredSize);
             assertThat(strings).hasSize(desiredSize).doesNotHaveDuplicates();
 
-            var uniqueLowerCaseStrings = strings.stream().map(String::toLowerCase).collect(toSet());
+            var uniqueLowerCaseStrings = strings.stream().map(String::toLowerCase).collect(toUnmodifiableSet());
             assertThat(uniqueLowerCaseStrings).containsExactly(input.toLowerCase());
         }
     }

--- a/src/test/java/org/kiwiproject/beta/concurrent/AutoDrainingCounterTest.java
+++ b/src/test/java/org/kiwiproject/beta/concurrent/AutoDrainingCounterTest.java
@@ -47,9 +47,9 @@ class AutoDrainingCounterTest {
     @Disabled
     void runExample() {
         var drainPeriod = Duration.ofSeconds(10);
-        var counter = AutoDrainingCounter.createAndStart(drainPeriod);
+        var startedCounter = AutoDrainingCounter.createAndStart(drainPeriod);
 
-        runCounter(counter);
+        runCounter(startedCounter);
     }
 
     /**
@@ -61,9 +61,9 @@ class AutoDrainingCounterTest {
     void runExampleWithCallback() {
         var drainPeriod = Duration.ofSeconds(10);
         var totalCount = new AtomicInteger();
-        var counter = AutoDrainingCounter.createAndStart(drainPeriod, totalCount::addAndGet);
+        var startedCounter = AutoDrainingCounter.createAndStart(drainPeriod, totalCount::addAndGet);
 
-        runCounter(counter);
+        runCounter(startedCounter);
 
         LOG.info("Total count: {}", totalCount.get());
     }

--- a/src/test/java/org/kiwiproject/beta/jdbc/KiwiJdbc2Test.java
+++ b/src/test/java/org/kiwiproject/beta/jdbc/KiwiJdbc2Test.java
@@ -1,7 +1,6 @@
 package org.kiwiproject.beta.jdbc;
 
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toSet;
+import static java.util.stream.Collectors.toUnmodifiableSet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
@@ -69,7 +68,7 @@ public class KiwiJdbc2Test {
 
             List<Long> luckyNumbers = KiwiJdbc2.arrayAsList(resultSet, "lucky_numbers", Long.class);
 
-            var expectedValues = Arrays.stream(values).boxed().collect(toList());
+            var expectedValues = Arrays.stream(values).boxed().toList();
             assertThat(luckyNumbers).containsExactlyElementsOf(expectedValues);
 
             verify(resultSet).getArray("lucky_numbers");
@@ -111,7 +110,7 @@ public class KiwiJdbc2Test {
 
             Set<Integer> luckyNumbers = KiwiJdbc2.arrayAsSet(resultSet, "lucky_numbers", Integer.class);
 
-            var expectedValues = Arrays.stream(values).boxed().collect(toSet());
+            var expectedValues = Arrays.stream(values).boxed().collect(toUnmodifiableSet());
             assertThat(luckyNumbers).containsExactlyInAnyOrderElementsOf(expectedValues);
 
             verify(resultSet).getArray("lucky_numbers");

--- a/src/test/java/org/kiwiproject/beta/net/KiwiUrls2Test.java
+++ b/src/test/java/org/kiwiproject/beta/net/KiwiUrls2Test.java
@@ -1,6 +1,5 @@
 package org.kiwiproject.beta.net;
 
-import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
@@ -41,7 +40,7 @@ class KiwiUrls2Test {
                             "https://dev-jump-proxy-1.acme.com/proxy/discovery",
                             "https://dev-jump-proxy-2.acme.com/proxy/discovery")
                     .map(KiwiUrls::createUrlObject)
-                    .collect(toList());
+                    .toList();
 
             var uniqueHostOnlyUrls = KiwiUrls2.uniqueHostOnlyUrls(urls);
 
@@ -63,7 +62,7 @@ class KiwiUrls2Test {
                             "https://dev-jump-proxy-1.acme.com:7443/proxy/discovery",
                             "https://dev-jump-proxy-2.acme.com:7443/proxy/discovery")
                     .map(KiwiUrls::createUrlObject)
-                    .collect(toList());
+                    .toList();
 
             var uniqueHostOnlyUrls = KiwiUrls2.uniqueHostOnlyUrls(urls);
 
@@ -99,7 +98,7 @@ class KiwiUrls2Test {
                             "https://dev-jump-proxy-1.acme.com/proxy/discovery",
                             "https://dev-jump-proxy-2.acme.com/proxy/discovery")
                     .map(KiwiUrls::createUrlObject)
-                    .collect(toList());
+                    .toList();
 
             var uniqueAuthorityOnlyUrls = KiwiUrls2.uniqueAuthorityOnlyUrls(urls);
 
@@ -121,7 +120,7 @@ class KiwiUrls2Test {
                             "https://dev-jump-proxy-1.acme.com:7443/proxy/discovery",
                             "https://dev-jump-proxy-2.acme.com:7443/proxy/discovery")
                     .map(KiwiUrls::createUrlObject)
-                    .collect(toList());
+                    .toList();
 
             var uniqueAuthorityOnlyUrls = KiwiUrls2.uniqueAuthorityOnlyUrls(urls);
 
@@ -157,7 +156,7 @@ class KiwiUrls2Test {
                             "https://dev-jump-proxy-1.acme.com/proxy/discovery",
                             "https://dev-jump-proxy-2.acme.com/proxy/discovery")
                     .map(KiwiUrls::createUrlObject)
-                    .collect(toList());
+                    .toList();
 
             var uniqueAuthorityOnlyUrls = KiwiUrls2.uniqueAuthorityOnlyUrlsAsList(urls);
 
@@ -179,7 +178,7 @@ class KiwiUrls2Test {
                             "https://dev-jump-proxy-1.acme.com:7443/proxy/discovery",
                             "https://dev-jump-proxy-2.acme.com:7443/proxy/discovery")
                     .map(KiwiUrls::createUrlObject)
-                    .collect(toList());
+                    .toList();
 
             var uniqueAuthorityOnlyUrls = KiwiUrls2.uniqueAuthorityOnlyUrlsAsList(urls);
 
@@ -205,9 +204,11 @@ class KiwiUrls2Test {
                 "https://dev-jump-proxy-1.acme.com/proxy/registry1/eureka",
                 "https://dev-jump-proxy-1.acme.com/proxy/registry2/eureka",
                 "https://dev-jump-proxy-1.acme.com/proxy/registry1/consul",
-                "https://dev-jump-proxy-1.acme.com/proxy/discovery"
+                "https://dev-jump-proxy-1.acme.com/proxy/discovery",
+                "https://dev-jump-proxy-1.acme.com/proxy/registry1/eureka?param1=value1",
+                "https://dev-jump-proxy-1.acme.com/proxy/discovery/param1=value1&param2=value2"
         })
-        void shouldRemovePaths(String urlSpec) {
+        void shouldRemovePathsAndQueryStrings(String urlSpec) {
             var url = KiwiUrls.createUrlObject(urlSpec);
             var modifiedUri = KiwiUrls2.hostOnlyUrlFrom(url);
             assertThat(modifiedUri).hasToString("https://dev-jump-proxy-1.acme.com");
@@ -218,31 +219,11 @@ class KiwiUrls2Test {
                 "https://dev-jump-proxy-1.acme.com:8443/proxy/registry1/eureka",
                 "https://dev-jump-proxy-1.acme.com:8443/proxy/registry2/eureka",
                 "https://dev-jump-proxy-1.acme.com:8443/proxy/registry1/consul",
-                "https://dev-jump-proxy-1.acme.com:8443/proxy/discovery"
-        })
-        void shouldRemovePaths_AndRetainPort(String urlSpec) {
-            var url = KiwiUrls.createUrlObject(urlSpec);
-            var modifiedUri = KiwiUrls2.hostOnlyUrlFrom(url);
-            assertThat(modifiedUri).hasToString("https://dev-jump-proxy-1.acme.com:8443");
-        }
-
-        @ParameterizedTest
-        @ValueSource(strings = {
-                "https://dev-jump-proxy-1.acme.com/proxy/registry1/eureka?param1=value1",
-                "https://dev-jump-proxy-1.acme.com/proxy/discovery/param1=value1&param2=value2"
-        })
-        void shouldRemoveQueryStrings(String urlSpec) {
-            var url = KiwiUrls.createUrlObject(urlSpec);
-            var modifiedUri = KiwiUrls2.hostOnlyUrlFrom(url);
-            assertThat(modifiedUri).hasToString("https://dev-jump-proxy-1.acme.com");
-        }
-
-        @ParameterizedTest
-        @ValueSource(strings = {
+                "https://dev-jump-proxy-1.acme.com:8443/proxy/discovery",
                 "https://dev-jump-proxy-1.acme.com:8443/proxy/registry1/eureka?param1=value1",
                 "https://dev-jump-proxy-1.acme.com:8443/proxy/discovery/param1=value1&param2=value2"
         })
-        void shouldRemoveQueryStrings_AndRetainPort(String urlSpec) {
+        void shouldRemovePathsandQueryStrings_ButRetainPort(String urlSpec) {
             var url = KiwiUrls.createUrlObject(urlSpec);
             var modifiedUri = KiwiUrls2.hostOnlyUrlFrom(url);
             assertThat(modifiedUri).hasToString("https://dev-jump-proxy-1.acme.com:8443");
@@ -262,29 +243,7 @@ class KiwiUrls2Test {
                 "https://dev-jump-proxy-1.acme.com/proxy/registry1/eureka",
                 "https://dev-jump-proxy-1.acme.com/proxy/registry2/eureka",
                 "https://dev-jump-proxy-1.acme.com/proxy/registry1/consul",
-                "https://dev-jump-proxy-1.acme.com/proxy/discovery"
-        })
-        void shouldRemovePaths(String urlSpec) {
-            var url = KiwiUrls.createUrlObject(urlSpec);
-            var modifiedUri = KiwiUrls2.authorityOnlyUrlFrom(url);
-            assertThat(modifiedUri).hasToString("https://dev-jump-proxy-1.acme.com");
-        }
-
-        @ParameterizedTest
-        @ValueSource(strings = {
-                "https://dev-jump-proxy-1.acme.com:8443/proxy/registry1/eureka",
-                "https://dev-jump-proxy-1.acme.com:8443/proxy/registry2/eureka",
-                "https://dev-jump-proxy-1.acme.com:8443/proxy/registry1/consul",
-                "https://dev-jump-proxy-1.acme.com:8443/proxy/discovery"
-        })
-        void shouldRemovePaths_AndRetainPort(String urlSpec) {
-            var url = KiwiUrls.createUrlObject(urlSpec);
-            var modifiedUri = KiwiUrls2.authorityOnlyUrlFrom(url);
-            assertThat(modifiedUri).hasToString("https://dev-jump-proxy-1.acme.com:8443");
-        }
-
-        @ParameterizedTest
-        @ValueSource(strings = {
+                "https://dev-jump-proxy-1.acme.com/proxy/discovery",
                 "https://dev-jump-proxy-1.acme.com/proxy/registry1/eureka?param1=value1",
                 "https://dev-jump-proxy-1.acme.com/proxy/discovery/param1=value1&param2=value2"
         })
@@ -296,6 +255,10 @@ class KiwiUrls2Test {
 
         @ParameterizedTest
         @ValueSource(strings = {
+                "https://dev-jump-proxy-1.acme.com:8443/proxy/registry1/eureka",
+                "https://dev-jump-proxy-1.acme.com:8443/proxy/registry2/eureka",
+                "https://dev-jump-proxy-1.acme.com:8443/proxy/registry1/consul",
+                "https://dev-jump-proxy-1.acme.com:8443/proxy/discovery",
                 "https://dev-jump-proxy-1.acme.com:8443/proxy/registry1/eureka?param1=value1",
                 "https://dev-jump-proxy-1.acme.com:8443/proxy/discovery/param1=value1&param2=value2"
         })

--- a/src/test/java/org/kiwiproject/beta/slf4j/TimestampingLoggerTest.java
+++ b/src/test/java/org/kiwiproject/beta/slf4j/TimestampingLoggerTest.java
@@ -1,6 +1,5 @@
 package org.kiwiproject.beta.slf4j;
 
-import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.Index.atIndex;
 import static org.kiwiproject.base.KiwiPreconditions.checkEvenItemCount;
@@ -142,7 +141,7 @@ class TimestampingLoggerTest {
 
         var timeSpentMessages = eventMessages.stream()
                 .filter(eventMessage -> eventMessage.startsWith("[elapsed time since previous:"))
-                .collect(toList());
+                .toList();
 
         assertThat(timeSpentMessages)
                 .describedAs("Should have five messages with elapsed time")


### PR DESCRIPTION
* Return unmodifiable Set from KiwiUrls2#uniqueAuthorityOnlyUrls (#418)
* Return unmodifiable Map from JarManifests#getMainAttributesAsMap (#419)
* Sonar cleanup:
  - "Stream.toList()" method should be used instead of "collectors" when unmodifiable list needed java:S6204
  - Methods should not have identical implementations java:S4144
  - Local variables should not shadow class fields java:S1117

Closes #418
Closes #419