### PR TITLE
New methods in KiwiMediaType

### DIFF
--- a/src/main/java/org/kiwiproject/beta/net/KiwiMediaTypes.java
+++ b/src/main/java/org/kiwiproject/beta/net/KiwiMediaTypes.java
@@ -11,8 +11,8 @@ import static org.kiwiproject.base.KiwiStrings.f;
 import com.google.common.annotations.Beta;
 import com.google.common.net.MediaType;
 import lombok.experimental.UtilityClass;
-
 import org.apache.commons.lang3.StringUtils;
+
 import java.util.Set;
 
 /**
@@ -121,7 +121,7 @@ public class KiwiMediaTypes {
      * that "text/plain; version=0.0.4; charset=utf-8" is considered plain text.
      *
      * @param mediaType the media type to check
-     * @return
+     * @return true if the media type is plain text ignoring any parameters, otherwise false
      */
     public static boolean isPlainText(String mediaType) {
         return matchesTypeAndSubtype(mediaType, TEXT_TYPE, PLAIN_SUBTYPE);
@@ -267,15 +267,15 @@ public class KiwiMediaTypes {
     /**
      * Checks if the given media type has type and subtype that matches the given values.
      * <p>
-     * This method lets you test for subtypes which can have more than one type, for example
-     * "application/xml" and "text/xml" are both considered valid XML types.
+     * This method lets you test for subtypes which can have more than one type.
+     * For example, "application/xml" and "text/xml" are both considered valid XML types.
      * <p>
      * To use this method,
      * the <a href="https://mvnrepository.com/artifact/jakarta.ws.rs/jakarta.ws.rs-api">jakarta.ws.rs:jakarta.ws.rs-api</a>
      * dependency must be present.
      *
      * @param mediaType the Jakarta Rest media type to check
-     * @param typesToMatch the types to match (any one is considered a match)
+     * @param typesToMatch the types to match (any one of them is considered a match)
      * @param subtypeToMatch the subtype to match
      * @return true if the type is any of the acceptable types and subtype matches, otherwise false
      */
@@ -293,11 +293,11 @@ public class KiwiMediaTypes {
     /**
      * Checks if the given media type has type and subtype that matches the given values.
      * <p>
-     * This method lets you test for subtypes which can have more than one type, for example
-     * "application/xml" and "text/xml" are both considered valid XML types.
+     * This method lets you test for subtypes which can have more than one type.
+     * For example, "application/xml" and "text/xml" are both considered valid XML types.
      *
      * @param mediaType the media type to check
-     * @param typesToMatch the types to match (any one is considered a match)
+     * @param typesToMatch the types to match (any one of them is considered a match)
      * @param subtypeToMatch the subtype to match
      * @return true if the type is any of the acceptable types and subtype matches, otherwise false
      */

--- a/src/main/java/org/kiwiproject/beta/net/KiwiMediaTypes.java
+++ b/src/main/java/org/kiwiproject/beta/net/KiwiMediaTypes.java
@@ -1,6 +1,10 @@
 package org.kiwiproject.beta.net;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.apache.commons.lang3.StringUtils.contains;
+import static org.apache.commons.lang3.StringUtils.indexOf;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotBlank;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotEmpty;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 import static org.kiwiproject.base.KiwiStrings.f;
 
@@ -8,8 +12,13 @@ import com.google.common.annotations.Beta;
 import com.google.common.net.MediaType;
 import lombok.experimental.UtilityClass;
 
+import org.apache.commons.lang3.StringUtils;
+import java.util.Set;
+
 /**
  * Some utilities for working with <a href="https://en.wikipedia.org/wiki/Media_type">media types</a>.
+ * Mozilla also has a good reference that describes
+ * <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types">MIME types (IANA media types)</a>.
  * <p>
  * Google Guava contains the <a href="https://javadoc.io/doc/com.google.guava/guava/latest/com/google/common/net/MediaType.html">MediaType</a>
  * class which represents an Internet Media Type. It contains some useful methods, but not some (what we think are)
@@ -18,12 +27,12 @@ import lombok.experimental.UtilityClass;
  * account. But the Guava {@code MediaType#is} method doesn't permit comparing like this when the type is different
  * but the subtype is the same.
  * <p>
- * The Jakarta RS <a href="https://javadoc.io/doc/jakarta.ws.rs/jakarta.ws.rs-api/latest/jakarta.ws.rs/jakarta/ws/rs/core/MediaType.html">MediaType</a>
+ * The Jakarta Rest <a href="https://javadoc.io/doc/jakarta.ws.rs/jakarta.ws.rs-api/latest/jakarta.ws.rs/jakarta/ws/rs/core/MediaType.html">MediaType</a>
  * is also useful, but its {@code equals} method unfortunately compares type, subtype, <em>and parameters</em> so
  * you cannot use it to check if a media type such as "text/xml; charset=utf-8" equals the "text/xml" media type,
  * since it will include the charset parameter in the comparison and return false.
  *
- * @implNote Internally this uses Guava's {@code MediaType} to parse String media types.
+ * @implNote Internally this uses Guava's {@link MediaType} to parse String media types.
  */
 @UtilityClass
 @Beta
@@ -31,23 +40,26 @@ public class KiwiMediaTypes {
 
     private static final String APPLICATION_TYPE = "application";
     private static final String TEXT_TYPE = "text";
+    private static final Set<String> XML_TYPES = Set.of(TEXT_TYPE, APPLICATION_TYPE);
+
     private static final String JSON_SUBTYPE = "json";
+    private static final String PLAIN_SUBTYPE = "plain";
     private static final String XML_SUBTYPE = "xml";
 
     /**
-     * Checks if the media type is "application/xml" or "text/xml", ignoring parameters such that
+     * Checks if the Jakarta Rest media type is "application/xml" or "text/xml", ignoring parameters such that
      * "text/xml; charset=utf-8" is considered XML.
      * <p>
      * To use this method,
      * the <a href="https://mvnrepository.com/artifact/jakarta.ws.rs/jakarta.ws.rs-api">jakarta.ws.rs:jakarta.ws.rs-api</a>
      * dependency must be present.
      *
-     * @param mediaType the media type to check
+     * @param mediaType the Jakarta Rest media type to check
      * @return true if the media type is an XML type ignoring any parameters, otherwise false
      */
     public static boolean isXml(jakarta.ws.rs.core.MediaType mediaType) {
-        checkArgumentNotNull(mediaType, "mediaType must not be null");
-        return isXml(toStringWithoutParameters(mediaType));
+        checkJakartaMediaType(mediaType);
+        return isXml(mediaType.toString());
     }
 
     /**
@@ -58,47 +70,71 @@ public class KiwiMediaTypes {
      * @return true if the media type is an XML type ignoring any parameters, otherwise false
      */
     public static boolean isXml(String mediaType) {
-        checkMediaTypeNotBlank(mediaType);
-        var parsedType = MediaType.parse(mediaType);
-        var type = parsedType.type();
-        var subtype = parsedType.subtype();
-        return (TEXT_TYPE.equals(type) || APPLICATION_TYPE.equals(type)) && XML_SUBTYPE.equals(subtype);
+        return matchesTypeAndSubtype(mediaType, XML_TYPES, XML_SUBTYPE);
     }
 
     /**
-     * Checks if the media type is "application/json", ignoring parameters such that "application/json; charset=utf-8"
-     * is considered JSON.
+     * Checks if the Jakarta Rest media type is "application/json", ignoring parameters such
+     * that "application/json; charset=utf-8" is considered JSON.
      * <p>
      * To use this method,
-     * the <a href="https://mvnrepository.com/search?q=akarta.ws.rs-api">jakarta.ws.rs:jakarta.ws.rs-api</a>
+     * the <a href="https://mvnrepository.com/artifact/jakarta.ws.rs/jakarta.ws.rs-api">jakarta.ws.rs:jakarta.ws.rs-api</a>
      * dependency must be present.
      *
-     * @param mediaType the media type to check
+     * @param mediaType the Jakarta Rest media type to check
      * @return true if the media type is JSON ignoring any parameters, otherwise false
      */
     public static boolean isJson(jakarta.ws.rs.core.MediaType mediaType) {
-        checkArgumentNotNull(mediaType, "mediaType must not be null");
-        return isJson(toStringWithoutParameters(mediaType));
+        checkJakartaMediaType(mediaType);
+        return isJson(mediaType.toString());
     }
 
     /**
-     * Checks if the media type is "application/json", ignoring parameters such that "application/json; charset=utf-8"
-     * is considered JSON.
+     * Checks if the media type is "application/json", ignoring parameters such
+     * that "application/json; charset=utf-8" is considered JSON.
      *
      * @param mediaType the media type to check
      * @return true if the media type is JSON ignoring any parameters, otherwise false
      */
     public static boolean isJson(String mediaType) {
-        checkMediaTypeNotBlank(mediaType);
-        var parsedType = MediaType.parse(mediaType);
-        var type = parsedType.type();
-        var subtype = parsedType.subtype();
-        return APPLICATION_TYPE.equals(type) && JSON_SUBTYPE.equals(subtype);
+        return matchesTypeAndSubtype(mediaType, APPLICATION_TYPE, JSON_SUBTYPE);
+    }
+
+    /**
+     * Checks if the Jakarta Rest media type is "text/plain", ignoring parameters such
+     * that "text/plain; version=0.0.4; charset=utf-8" is considered plain text.
+     * <p>
+     * To use this method,
+     * the <a href="https://mvnrepository.com/artifact/jakarta.ws.rs/jakarta.ws.rs-api">jakarta.ws.rs:jakarta.ws.rs-api</a>
+     * dependency must be present.
+     *
+     * @param mediaType the Jakarta Rest media type to check
+     * @return true if the media type is plain text ignoring any parameters, otherwise false
+     */
+    public static boolean isPlainText(jakarta.ws.rs.core.MediaType mediaType) {
+        checkJakartaMediaType(mediaType);
+        return isPlainText(mediaType.toString());
+    }
+
+    /**
+     * Checks if the media type is "text/plain", ignoring parameters such
+     * that "text/plain; version=0.0.4; charset=utf-8" is considered plain text.
+     *
+     * @param mediaType the media type to check
+     * @return
+     */
+    public static boolean isPlainText(String mediaType) {
+        return matchesTypeAndSubtype(mediaType, TEXT_TYPE, PLAIN_SUBTYPE);
     }
 
     /**
      * Get the string value of the given {@link jakarta.ws.rs.core.MediaType} with only the type/subtype.
+     * <p>
+     * To use this method,
+     * the <a href="https://mvnrepository.com/artifact/jakarta.ws.rs/jakarta.ws.rs-api">jakarta.ws.rs:jakarta.ws.rs-api</a>
+     * dependency must be present.
      *
+     * @param mediaType the Jakarta Rest media type to strip parameters from
      * @implNote This method concatenates the type and subtype of the MediaType because the
      * MediaType#toString requires a Jakarta RS implementation to create a RuntimeDelegate
      * which is then used to convert to a String. Presumably if this method is used, the implementation
@@ -107,7 +143,24 @@ public class KiwiMediaTypes {
      * implementation to be available.
      */
     public static String toStringWithoutParameters(jakarta.ws.rs.core.MediaType mediaType) {
+        checkJakartaMediaType(mediaType);
         return f("{}/{}", mediaType.getType(), mediaType.getSubtype());
+    }
+
+    /**
+     * Strip any parameters from {@code mediaType}, returning a value in the format {@code type/subtype}.
+     * <p>
+     * This is a convenience method that delegates to Guava's {@link MediaType} and which handles
+     * parsing the String value to a {@link MediaType}, removing the parameters, and converting to a String.
+     *
+     * @param mediaType the media type to strip parameters from
+     * @return the "plain" media type as {@code type/subtype}
+     * @see MediaType#parse(String)
+     * @see MediaType#withoutParameters
+     */
+    public static String withoutParameters(String mediaType) {
+        checkMediaTypeNotBlank(mediaType);
+        return MediaType.parse(mediaType).withoutParameters().toString();
     }
 
     /**
@@ -138,6 +191,129 @@ public class KiwiMediaTypes {
         var parsedType = MediaType.parse(mediaType);
         var subtype = parsedType.subtype();
         return subtypeToMatch.equals(subtype);
+    }
+
+    /**
+     * Checks if the given media type has a type and subtype that matches the given {@code type/subtype} media type.
+     * Ignores parameters in {@code mediaType} such as "version" and "charset" in
+     * {@code text/plain; version=0.0.4; charset=utf-8}.
+     * <p>
+     * To use this method,
+     * the <a href="https://mvnrepository.com/artifact/jakarta.ws.rs/jakarta.ws.rs-api">jakarta.ws.rs:jakarta.ws.rs-api</a>
+     * dependency must be present.
+     *
+     * @param mediaType the Jakarta Rest media type to check
+     * @param mediaTypeToMatch the media type to match (must be in exact format {@code type/subtype})
+     * @return true if the type and subtype both match ignoring parameters, otherwise false
+     */
+    public static boolean matchesMediaType(jakarta.ws.rs.core.MediaType mediaType, String mediaTypeToMatch) {
+        checkJakartaMediaType(mediaType);
+        return matchesMediaType(mediaType.toString(), mediaTypeToMatch);
+    }
+
+    /**
+     * Checks if the given media type has a type and subtype that matches the given {@code type/subtype} media type.
+     * Ignores parameters in {@code mediaType} such as "version" and "charset" in
+     * {@code text/plain; version=0.0.4; charset=utf-8}.
+     *
+     * @param mediaType the media type to check
+     * @param mediaTypeToMatch the media type to match (must be in exact format {@code type/subtype})
+     * @return true if the type and subtype both match ignoring parameters, otherwise false
+     */
+    public static boolean matchesMediaType(String mediaType, String mediaTypeToMatch) {
+        checkMediaTypeNotBlank(mediaType);
+
+        var slashIndex = indexOf(mediaTypeToMatch, '/');
+        checkArgument(slashIndex > -1 && !contains(mediaTypeToMatch, ';'),
+                "mediaTypeToMatch must not be blank and be in the format type/subtype");
+
+        var type = mediaTypeToMatch.substring(0, slashIndex);
+        var subtype = mediaTypeToMatch.substring(slashIndex + 1);
+        return matchesTypeAndSubtype(mediaType, type, subtype);
+    }
+
+    /**
+     * Checks if the given media type has type and subtype that matches the given values.
+     * <p>
+     * To use this method,
+     * the <a href="https://mvnrepository.com/artifact/jakarta.ws.rs/jakarta.ws.rs-api">jakarta.ws.rs:jakarta.ws.rs-api</a>
+     * dependency must be present.
+     *
+     * @param mediaType the Jakarta Rest media type to check
+     * @param typeToMatch the type to match
+     * @param subtypeToMatch the subtype to match
+     * @return true if the type and subtype both match, otherwise false
+     */
+    public static boolean matchesTypeAndSubtype(jakarta.ws.rs.core.MediaType mediaType,
+                                                String typeToMatch,
+                                                String subtypeToMatch) {
+        checkJakartaMediaType(mediaType);
+        return matchesTypeAndSubtype(mediaType.toString(), typeToMatch, subtypeToMatch);
+    }
+
+    /**
+     * Checks if the given media type has type and subtype that matches the given values.
+     *
+     * @param mediaType the media type to check
+     * @param typeToMatch the type to match
+     * @param subtypeToMatch the subtype to match
+     * @return true if the type and subtype both match, otherwise false
+     */
+    public static boolean matchesTypeAndSubtype(String mediaType, String typeToMatch, String subtypeToMatch) {
+        checkArgumentNotBlank(typeToMatch, "typeToMatch must not be blank");
+        return matchesTypeAndSubtype(mediaType, Set.of(typeToMatch), subtypeToMatch);
+    }
+
+    /**
+     * Checks if the given media type has type and subtype that matches the given values.
+     * <p>
+     * This method lets you test for subtypes which can have more than one type, for example
+     * "application/xml" and "text/xml" are both considered valid XML types.
+     * <p>
+     * To use this method,
+     * the <a href="https://mvnrepository.com/artifact/jakarta.ws.rs/jakarta.ws.rs-api">jakarta.ws.rs:jakarta.ws.rs-api</a>
+     * dependency must be present.
+     *
+     * @param mediaType the Jakarta Rest media type to check
+     * @param typesToMatch the types to match (any one is considered a match)
+     * @param subtypeToMatch the subtype to match
+     * @return true if the type is any of the acceptable types and subtype matches, otherwise false
+     */
+    public static boolean matchesTypeAndSubtype(jakarta.ws.rs.core.MediaType mediaType,
+                                                Set<String> typesToMatch,
+                                                String subtypeToMatch) {
+        checkJakartaMediaType(mediaType);
+        return matchesTypeAndSubtype(mediaType.toString(), typesToMatch, subtypeToMatch);
+    }
+
+    private static void checkJakartaMediaType(jakarta.ws.rs.core.MediaType mediaType) {
+        checkArgumentNotNull(mediaType, "mediaType must not be null");
+    }
+
+    /**
+     * Checks if the given media type has type and subtype that matches the given values.
+     * <p>
+     * This method lets you test for subtypes which can have more than one type, for example
+     * "application/xml" and "text/xml" are both considered valid XML types.
+     *
+     * @param mediaType the media type to check
+     * @param typesToMatch the types to match (any one is considered a match)
+     * @param subtypeToMatch the subtype to match
+     * @return true if the type is any of the acceptable types and subtype matches, otherwise false
+     */
+    public static boolean matchesTypeAndSubtype(String mediaType, Set<String> typesToMatch, String subtypeToMatch) {
+        checkMediaTypeNotBlank(mediaType);
+        checkArgumentNotEmpty(typesToMatch, "typesToMatch must not be empty");
+
+        var anyBlank = typesToMatch.stream().anyMatch(StringUtils::isBlank);
+        checkArgument(!anyBlank, "typesToMatch must not contain blank elements");
+
+        checkArgumentNotBlank(subtypeToMatch, "subtypeToMatch must not be blank");
+
+        var parsedType = MediaType.parse(mediaType);
+        var type = parsedType.type();
+        var subtype = parsedType.subtype();
+        return typesToMatch.contains(type) && subtypeToMatch.equals(subtype);
     }
 
     private static void checkMediaTypeNotBlank(String mediaType) {

--- a/src/test/java/org/kiwiproject/beta/net/KiwiMediaTypesTest.java
+++ b/src/test/java/org/kiwiproject/beta/net/KiwiMediaTypesTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import com.google.common.collect.Sets;
-
 import jakarta.ws.rs.core.MediaType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -368,8 +367,8 @@ class KiwiMediaTypesTest {
             text/plain, application/json, false
             """,
             nullValues = "null")
-        void shouldBeTrue_WhenTypeAndSubtypeMatch(String mediaType, String mediaTypetoMatch, boolean expectMatch) {
-            assertThat(KiwiMediaTypes.matchesMediaType(mediaType, mediaTypetoMatch))
+        void shouldBeTrue_WhenTypeAndSubtypeMatch(String mediaType, String mediaTypeToMatch, boolean expectMatch) {
+            assertThat(KiwiMediaTypes.matchesMediaType(mediaType, mediaTypeToMatch))
                     .isEqualTo(expectMatch);
         }
     }
@@ -409,10 +408,10 @@ class KiwiMediaTypesTest {
             text/plain, application/json, false
             """,
             nullValues = "null")
-        void shouldBeTrue_WhenTypeAndSubtypeMatch(String mediaType, String mediaTypetoMatch, boolean expectMatch) {
+        void shouldBeTrue_WhenTypeAndSubtypeMatch(String mediaType, String mediaTypeToMatch, boolean expectMatch) {
             var jakartaMediaType = MediaType.valueOf(mediaType);
 
-            assertThat(KiwiMediaTypes.matchesMediaType(jakartaMediaType, mediaTypetoMatch))
+            assertThat(KiwiMediaTypes.matchesMediaType(jakartaMediaType, mediaTypeToMatch))
                     .isEqualTo(expectMatch);
         }
     }

--- a/src/test/java/org/kiwiproject/beta/net/KiwiMediaTypesTest.java
+++ b/src/test/java/org/kiwiproject/beta/net/KiwiMediaTypesTest.java
@@ -3,13 +3,20 @@ package org.kiwiproject.beta.net;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
+import com.google.common.collect.Sets;
+
 import jakarta.ws.rs.core.MediaType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.kiwiproject.test.junit.jupiter.params.provider.AsciiOnlyBlankStringSource;
+import org.kiwiproject.test.junit.jupiter.params.provider.MinimalBlankStringSource;
+
+import java.util.Set;
 
 @DisplayName("KiwiMediaTypes")
 class KiwiMediaTypesTest {
@@ -146,23 +153,126 @@ class KiwiMediaTypesTest {
         }
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = {
-            "text/xml",
-            "text/xml; charset=utf-8",
-            "application/xml",
-            "application/xml; charset=utf-8",
-            "application/json",
-            "application/json; charset=utf-8",
-            "text/html; charset=utf-8",
-            "text/html; charset=ISO-8859-1",
-    })
-    void shouldReturnJakartaMediaTypeAsStringWithoutParameters(String mediaType) {
-        var jakartaMediaType = MediaType.valueOf(mediaType);
-        var plainMediaType = KiwiMediaTypes.toStringWithoutParameters(jakartaMediaType);
+    @Nested
+    class IsPlainText {
 
-        var expectedMediaType = com.google.common.net.MediaType.parse(mediaType).withoutParameters().toString();
-        assertThat(plainMediaType).isEqualTo(expectedMediaType);
+        @ParameterizedTest
+        @AsciiOnlyBlankStringSource
+        void shouldNotAllowBlankMediaType(String value) {
+            assertThatIllegalArgumentException().isThrownBy(() -> KiwiMediaTypes.isPlainText(value));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "text/plain",
+            "text/plain; charset=utf-8",
+            "text/plain; version=0.0.4; charset=utf-8",
+            "text/plain; charset=ISO-8859-1",
+        })
+        void shouldBeTrue_WhenGivenAnAcceptablePlainTextType(String mediaType) {
+            assertThat(KiwiMediaTypes.isPlainText(mediaType)).isTrue();
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "application/xml",
+            "text/css",
+            "text/html; charset=utf-8",
+            "text/xml; charset=ISO-8859-1",
+            "image/jpeg"
+        })
+        void shouldBeFalse_WhenNotPlainTxtType(String mediaType) {
+            assertThat(KiwiMediaTypes.isPlainText(mediaType)).isFalse();
+        }
+    }
+
+    @Nested
+    class IsPlainTextWithJakartaMediaType {
+
+        @Test
+        void shouldNotAllowNullMediaType() {
+            assertThatIllegalArgumentException().isThrownBy(() -> KiwiMediaTypes.isPlainText((MediaType) null));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "text/plain",
+            "text/plain; charset=utf-8",
+            "text/plain; version=0.0.4; charset=utf-8",
+            "text/plain; charset=ISO-8859-1",
+        })
+        void shouldBeTrue_WhenGivenAnAcceptablePlainTextType(String mediaType) {
+            assertThat(KiwiMediaTypes.isPlainText(MediaType.valueOf(mediaType))).isTrue();
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "application/xml",
+            "text/css",
+            "text/html; charset=utf-8",
+            "text/xml; charset=ISO-8859-1",
+            "image/jpeg"
+        })
+        void shouldBeFalse_WhenNotPlainTxtType(String mediaType) {
+            assertThat(KiwiMediaTypes.isPlainText(MediaType.valueOf(mediaType))).isFalse();
+        }
+    }
+
+    @Nested
+    class ToStringWithoutParameters {
+
+        @Test
+        void shouldNowAllowNullArgument() {
+            assertThatIllegalArgumentException().isThrownBy(() ->
+                    KiwiMediaTypes.toStringWithoutParameters(null));
+        }
+
+        @ParameterizedTest
+        @CsvSource(textBlock = """
+                text/xml, text/xml
+                text/xml; charset=utf-8, text/xml
+                application/xml, application/xml
+                application/xml; charset=utf-8, application/xml
+                application/json, application/json
+                application/json; charset=utf-8, application/json
+                text/html; charset=utf-8, text/html
+                text/html; charset=ISO-8859-1, text/html
+                'text/plain; version=0.0.4; charset=utf-8', text/plain
+                """)
+        void shouldReturnJakartaMediaTypeAsStringWithoutParameters(String mediaType, String expectedResult) {
+            var jakartaMediaType = MediaType.valueOf(mediaType);
+            var plainMediaType = KiwiMediaTypes.toStringWithoutParameters(jakartaMediaType);
+
+            assertThat(plainMediaType).isEqualTo(expectedResult);
+        }
+    }
+
+    @Nested
+    class WithoutParameters {
+
+        @ParameterizedTest
+        @MinimalBlankStringSource
+        void shouldNotAllowBlankArguments(String value) {
+            assertThatIllegalArgumentException().isThrownBy(() ->
+                    KiwiMediaTypes.withoutParameters(value));
+        }
+
+        @ParameterizedTest
+        @CsvSource(textBlock = """
+                text/xml, text/xml
+                text/xml; charset=utf-8, text/xml
+                application/xml, application/xml
+                application/xml; charset=utf-8, application/xml
+                application/json, application/json
+                application/json; charset=utf-8, application/json
+                text/html; charset=utf-8, text/html
+                text/html; charset=ISO-8859-1, text/html
+                'text/plain; version=0.0.4; charset=utf-8', text/plain
+                """)
+        void shouldStripParameters(String mediaType, String expectedResult) {
+            var plainMediaType = KiwiMediaTypes.withoutParameters(mediaType);
+            assertThat(plainMediaType).isEqualTo(expectedResult);
+        }
     }
 
     @Nested
@@ -171,7 +281,8 @@ class KiwiMediaTypesTest {
         @ParameterizedTest
         @AsciiOnlyBlankStringSource
         void shouldNotAllowBlankMediaType(String value) {
-            assertThatIllegalArgumentException().isThrownBy(() -> KiwiMediaTypes.matchesType(value, "text"));
+            assertThatIllegalArgumentException().isThrownBy(() ->
+                    KiwiMediaTypes.matchesType(value, "text"));
         }
 
         @ParameterizedTest
@@ -203,7 +314,8 @@ class KiwiMediaTypesTest {
         @ParameterizedTest
         @AsciiOnlyBlankStringSource
         void shouldNotAllowBlankMediaType(String value) {
-            assertThatIllegalArgumentException().isThrownBy(() -> KiwiMediaTypes.matchesSubtype(value, "xml"));
+            assertThatIllegalArgumentException().isThrownBy(() ->
+                    KiwiMediaTypes.matchesSubtype(value, "xml"));
         }
 
         @ParameterizedTest
@@ -224,6 +336,264 @@ class KiwiMediaTypesTest {
         })
         void shouldBeFalse_WhenSubtypesDoNotMatch(String mediaType) {
             assertThat(KiwiMediaTypes.matchesSubtype(mediaType, "json")).isFalse();
+        }
+    }
+
+    @Nested
+    class MatchesMediaType {
+
+        @ParameterizedTest
+        @CsvSource(textBlock = """
+            null, null,
+            '', ''
+            null, text/plain
+            '', text/plain
+            text/plain, null
+            text/plain, ''
+            """,
+            nullValues = "null")
+        void shouldNotAllowBlankArguments(String mediaType, String mediaTypeToMatch) {
+            assertThatIllegalArgumentException().isThrownBy(() ->
+                    KiwiMediaTypes.matchesMediaType(mediaType, mediaTypeToMatch));
+        }
+
+        @ParameterizedTest
+        @CsvSource(textBlock = """
+            application/json, application/json, true
+            text/xml, text/xml, true
+            text/plain, text/plain, true
+
+            text/xml, application/xml, false
+            application/json, application/xml, false
+            text/plain, application/json, false
+            """,
+            nullValues = "null")
+        void shouldBeTrue_WhenTypeAndSubtypeMatch(String mediaType, String mediaTypetoMatch, boolean expectMatch) {
+            assertThat(KiwiMediaTypes.matchesMediaType(mediaType, mediaTypetoMatch))
+                    .isEqualTo(expectMatch);
+        }
+    }
+
+    @Nested
+    class MatchesMediaTypeWithJakartaMediaType {
+
+        @Test
+        void shouldNotAllowNullJakartaMediaType() {
+            assertThatIllegalArgumentException().isThrownBy(() ->
+                    KiwiMediaTypes.matchesMediaType((MediaType) null, "application/json"));
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {
+            "application",
+            "json",
+            "text plain",
+            "application/json;",
+            "application/json; charset=utf-8",
+            "text/plain; version=0.0.4; charset=utf-8"
+        })
+        void shouldNotAllowBlankOrMalformedMediaTypeToMatch(String mediaTypeToMatch) {
+            assertThatIllegalArgumentException().isThrownBy(() ->
+                    KiwiMediaTypes.matchesMediaType(MediaType.APPLICATION_JSON_TYPE, mediaTypeToMatch));
+        }
+
+        @ParameterizedTest
+        @CsvSource(textBlock = """
+            application/json, application/json, true
+            text/xml, text/xml, true
+            text/plain, text/plain, true
+
+            text/xml, application/xml, false
+            application/json, application/xml, false
+            text/plain, application/json, false
+            """,
+            nullValues = "null")
+        void shouldBeTrue_WhenTypeAndSubtypeMatch(String mediaType, String mediaTypetoMatch, boolean expectMatch) {
+            var jakartaMediaType = MediaType.valueOf(mediaType);
+
+            assertThat(KiwiMediaTypes.matchesMediaType(jakartaMediaType, mediaTypetoMatch))
+                    .isEqualTo(expectMatch);
+        }
+    }
+
+    @Nested
+    class MatchesTypeAndSubtype {
+
+        @ParameterizedTest
+        @CsvSource(textBlock = """
+            null, null, null
+            null, text, xml
+            '', text, xml
+            text/plain, null, plain
+            text/plain, '', plain
+            application/json, application, null
+            application/json, application, ''
+            """,
+            nullValues = "null")
+        void shouldNotAllowBlankArguments(String mediaType, String typeToMatch, String subtypeToMatch) {
+            assertThatIllegalArgumentException().isThrownBy(() ->
+                    KiwiMediaTypes.matchesTypeAndSubtype(mediaType, typeToMatch, subtypeToMatch));
+        }
+
+        @ParameterizedTest
+        @CsvSource(textBlock = """
+            application/json, application, json, true
+            text/xml, text, xml, true
+            text/plain, text, plain, true
+
+            text/xml, application, xml, false
+            application/json, application, xml, false
+            text/plain, application, json, false
+            """,
+            nullValues = "null")
+        void shouldBeTrue_WhenTypeAndSubtypeMatch(String mediaType, String type, String subtype, boolean expectMatch) {
+            assertThat(KiwiMediaTypes.matchesTypeAndSubtype(mediaType, type, subtype))
+                    .isEqualTo(expectMatch);
+        }
+    }
+
+    @Nested
+    class MatchesTypeAndSubtypeWithJakartaMediaType {
+
+        @Test
+        void shouldNotAllowNullJakartaMediaType() {
+            assertThatIllegalArgumentException().isThrownBy(() ->
+                    KiwiMediaTypes.matchesTypeAndSubtype((MediaType) null, "application", "json"));
+        }
+
+        @ParameterizedTest
+        @CsvSource(textBlock = """
+            null, null
+            null, plain
+            '', plain
+            application, null
+            application, ''
+            """,
+            nullValues = "null")
+        void shouldNotAllowBlankArguments(String typeToMatch, String subtypeToMatch) {
+            assertThatIllegalArgumentException().isThrownBy(() ->
+                    KiwiMediaTypes.matchesTypeAndSubtype(MediaType.APPLICATION_JSON_TYPE, typeToMatch, subtypeToMatch));
+        }
+
+        @ParameterizedTest
+        @CsvSource(textBlock = """
+            application/json, application, json, true
+            text/xml, text, xml, true
+            text/plain, text, plain, true
+
+            text/xml, application, xml, false
+            application/json, application, xml, false
+            text/plain, application, json, false
+            """,
+            nullValues = "null")
+        void shouldBeTrue_WhenTypeAndSubtypeMatch(String mediaType, String type, String subtype, boolean expectMatch) {
+            var jakartaMediaType = MediaType.valueOf(mediaType);
+            assertThat(KiwiMediaTypes.matchesTypeAndSubtype(jakartaMediaType, type, subtype))
+                    .isEqualTo(expectMatch);
+        }
+    }
+
+    @Nested
+    class MatchesTypeAndSubtype_WithSetOfTypes {
+
+        @ParameterizedTest
+        @CsvSource(textBlock = """
+            null, null
+            '', ''
+            null, xml
+            '', xml
+            text/plain, null
+            text/plain, ''
+            """,
+            nullValues = "null")
+        void shouldNotAllowBlankArguments(String mediaType, String subtypeToMatch) {
+            assertThatIllegalArgumentException().isThrownBy(() ->
+                    KiwiMediaTypes.matchesTypeAndSubtype(mediaType, Set.of("text"), subtypeToMatch));
+        }
+
+        @Test
+        void shouldNotAllowEmptyTypesToMatch() {
+            Set<String> typesToMatch = Set.of();
+            assertThatIllegalArgumentException().isThrownBy(() ->
+                    KiwiMediaTypes.matchesTypeAndSubtype("text/xml", typesToMatch, "xml"));
+        }
+
+        @ParameterizedTest
+        @MinimalBlankStringSource
+        void shouldNotAllowBlankElementsInTypesToMatch(String value) {
+            var typesToMatch = Sets.newHashSet("text", value);  // use Guava's Sets b/c Set#of rejects null
+            assertThatIllegalArgumentException().isThrownBy(() ->
+                    KiwiMediaTypes.matchesTypeAndSubtype("text/xml", typesToMatch, "xml"));
+        }
+
+        @ParameterizedTest
+        @CsvSource(textBlock = """
+            application/json, application, json, true
+            text/xml, text, xml, true
+            text/plain, text, plain, true
+
+            text/xml, application, xml, false
+            application/json, application, xml, false
+            text/plain, application, json, false
+            """,
+            nullValues = "null")
+        void shouldBeTrue_WhenTypeAndSubtypeMatch(String mediaType, String type, String subtype, boolean expectMatch) {
+            var typesToMatch = Set.of(type);
+            assertThat(KiwiMediaTypes.matchesTypeAndSubtype(mediaType, typesToMatch, subtype))
+                    .isEqualTo(expectMatch);
+        }
+    }
+
+    @Nested
+    class MatchesTypeAndSubtype_WithSetOfTypes_WithJakartaMediaType {
+
+        @Test
+        void shouldNotAllowNullJakartaMediaType() {
+            var typesToMatch = Set.of("application");
+            assertThatIllegalArgumentException().isThrownBy(() ->
+                    KiwiMediaTypes.matchesTypeAndSubtype((MediaType) null, typesToMatch, "json"));
+        }
+
+        @Test
+        void shouldNotAllowEmptyTypesToMatch() {
+            Set<String> typesToMatch = Set.of();
+            assertThatIllegalArgumentException().isThrownBy(() ->
+                    KiwiMediaTypes.matchesTypeAndSubtype(MediaType.TEXT_XML_TYPE, typesToMatch, "xml"));
+        }
+
+        @ParameterizedTest
+        @MinimalBlankStringSource
+        void shouldNotAllowBlankElementsInTypesToMatch(String value) {
+            var typesToMatch = Sets.newHashSet("text", value);  // use Guava's Sets b/c Set#of rejects null
+            assertThatIllegalArgumentException().isThrownBy(() ->
+                    KiwiMediaTypes.matchesTypeAndSubtype(MediaType.TEXT_XML_TYPE, typesToMatch, "xml"));
+        }
+
+        @ParameterizedTest
+        @MinimalBlankStringSource
+        void shouldNotAllowBlankSubtypeToMatch(String value) {
+            var typesToMatch = Set.of("application");
+            assertThatIllegalArgumentException().isThrownBy(() ->
+                    KiwiMediaTypes.matchesTypeAndSubtype(MediaType.APPLICATION_JSON_TYPE, typesToMatch, value));
+        }
+
+        @ParameterizedTest
+        @CsvSource(textBlock = """
+            application/json, application, json, true
+            text/xml, text, xml, true
+            text/plain, text, plain, true
+
+            text/xml, application, xml, false
+            application/json, application, xml, false
+            text/plain, application, json, false
+            """,
+            nullValues = "null")
+        void shouldBeTrue_WhenTypeAndSubtypeMatch(String mediaType, String type, String subtype, boolean expectMatch) {
+            var jakartaMediaType = MediaType.valueOf(mediaType);
+            var typesToMatch = Set.of(type);
+            assertThat(KiwiMediaTypes.matchesTypeAndSubtype(jakartaMediaType, typesToMatch, subtype))
+                    .isEqualTo(expectMatch);
         }
     }
 }


### PR DESCRIPTION
* Add overloaded isPlainText methods (#424)
* Add matchesTypeAndSubtype (#425)
* Add  overloaded matchesMediaType (#426)
* Add overloaded matchesTypeAndSubtype (#427)
* Add withoutParameters (#428)
* Misc javadoc  updates

Closes #424
Closes #425
Closes #426
Closes #427
Closes #428