### PR TITLE
Add new methods to Timing that don't require an explicit StopWatch

### DIFF
--- a/src/main/java/org/kiwiproject/beta/time/Timing.java
+++ b/src/main/java/org/kiwiproject/beta/time/Timing.java
@@ -1,10 +1,16 @@
 package org.kiwiproject.beta.time;
 
+import static java.util.Objects.nonNull;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
+
 import com.google.common.annotations.Beta;
+import com.google.errorprone.annotations.CheckReturnValue;
 import lombok.Value;
 import lombok.experimental.UtilityClass;
 import org.apache.commons.lang3.time.StopWatch;
 
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 /**
@@ -14,12 +20,19 @@ import java.util.function.Supplier;
 @UtilityClass
 public class Timing {
 
+    // TODO Add nanos to original interfaces/methods. This is a public API change b/c of ctors!
+
     /**
      * Represents an operation that is timed.
+     * <p>
+     * Note this only provides millisecond precision. It may be changed in a future release.
+     * The methods using this interface and its implementations require an explicit
+     * {@link StopWatch}. If you need nanoseconds, you can call {@link StopWatch#getNanoTime()}
+     * on it since the timing methods is always stopped once the operation has completed.
      */
-    public interface Timed {
+    public sealed interface Timed permits TimedWithResult, TimedNoResult {
         /**
-         * @return the number of milliseconds that have elapsed since the operation started
+         * @return the number of milliseconds that elapsed during the operation
          */
         long getElapsedMillis();
     }
@@ -51,7 +64,7 @@ public class Timing {
      * throws an exception.
      * <p>
      * If you need the elapsed time when an exception is thrown, you can simply call
-     * {@link StopWatch#getTime()}.
+     * {@link StopWatch#getTime()} or {@link StopWatch#getNanoTime()}.
      * <p>
      * Since {@link StopWatch} is not thread-safe, callers are responsible for ensuring
      * thread-safety. Passing it as an argument permits timing more than one sequential operation
@@ -83,7 +96,7 @@ public class Timing {
      * throws an exception.
      * <p>
      * If you need the elapsed time when an exception is thrown, you can simply call
-     * {@link StopWatch#getTime()}.
+     * {@link StopWatch#getTime()} or {@link StopWatch#getNanoTime()}.
      * <p>
      * Since {@link StopWatch} is not thread-safe, callers are responsible for ensuring
      * thread-safety. Passing it as an argument permits timing more than one sequential operation
@@ -103,5 +116,210 @@ public class Timing {
             stopWatch.stop();
         }
         return new TimedNoResult(stopWatch.getTime());
+    }
+
+    /**
+     * Represents an operation that is timed and may throw a runtime exception.
+     *
+     * @apiNote This uses RuntimeException rather than Exception because the timing
+     * methods accept a Runnable or a Supplier, which can only throw RuntimeException.
+     */
+    public sealed interface TimedWithError
+            permits TimedWithErrorOrResult, TimedWithErrorNoResult {
+
+        /**
+         * @return the number of nanoseconds that elapsed during the operation
+         */
+        long getElapsedNanos();
+
+        /**
+         * @return the number of milliseconds that elapsed during the operation
+         */
+        default long getElapsedMillis() {
+            return TimeUnit.NANOSECONDS.toMillis(getElapsedNanos());
+        }
+
+        /**
+         * @return true if the operation completed without exception, otherwise false
+         */
+        default boolean operationSucceeded() {
+            return !hasException();
+        }
+
+        /**
+         * @return true if the operation threw an exception, otherwise false
+         */
+        default boolean hasException() {
+            return getException().isPresent();
+        }
+
+        /**
+         * @return an Optional that will contain a RuntimeException if the operation failed.
+         * If called when the operation succeeded, an empty Optional is always returned.
+         */
+        Optional<RuntimeException> getException();
+    }
+
+    /**
+     * Represents an operation that is timed and returns a (possibly null) result, but may throw an exception.
+     *
+     * @param <R> the result type
+     */
+    @Value
+    public static class TimedWithErrorOrResult<R> implements TimedWithError {
+        long elapsedNanos;
+        R result;
+        RuntimeException exception;
+
+        /**
+         * Create a new instance containing a result.
+         *
+         * @param <R> the result type
+         * @param elapsedNanos the number of nanoseconds that elapsed during the operation
+         * @param result the result of the operation, may be null
+         * @return a new instance representing a successful operation
+         */
+        public static <R> TimedWithErrorOrResult<R> ofResult(long elapsedNanos, R result) {
+            return new TimedWithErrorOrResult<R>(elapsedNanos, result, null);
+        }
+
+        /**
+         * Create a new instance containing an exception.
+         *
+         * @param <R> the result type
+         * @param elapsedNanos the number of nanoseconds that elapsed during the operation
+         * @param exception the exception thrown by the operation
+         * @return a new instance representing a failed operation
+         */
+        public static <R> TimedWithErrorOrResult<R> ofException(long elapsedNanos, RuntimeException exception) {
+            checkArgumentNotNull(exception, "exception must not be null");
+            return new TimedWithErrorOrResult<R>(elapsedNanos, null, exception);
+        }
+
+        /**
+         * Create a new instance containing either a result or an exception.
+         *
+         * @param elapsedNanos the number of nanoseconds that elapsed during the operation
+         * @param result the result of the operation, may be null
+         * @param exception the exception thrown by the operation, may be null
+         * @throws IllegalArgumentException if both result and exception are non-null
+         */
+        public TimedWithErrorOrResult(long elapsedNanos, R result, RuntimeException exception) {
+            if (nonNull(result) && nonNull(exception)) {
+                throw new IllegalArgumentException("Cannot contain a result and an exception");
+            }
+
+            this.elapsedNanos = elapsedNanos;
+            this.result = result;
+            this.exception = exception;
+        }
+
+        /**
+         * @return true if the operation succeeeded and contains a (possibly null) result
+         */
+        public boolean hasResult() {
+            return operationSucceeded();
+        }
+
+        /**
+         * @return an Optional that will contain a (possibly null) result when the operation succeeds.
+         * If called when the operation failed, an empty Optional is always returned.
+         */
+        public Optional<R> getResult() {
+            return Optional.ofNullable(result);
+        }
+
+        /**
+         * @return true if the operation completed without exception and the actual result is null.
+         */
+        public boolean isNullResult() {
+            return operationSucceeded() && getResult().isEmpty();
+        }
+
+        @Override
+        public Optional<RuntimeException> getException() {
+            return Optional.ofNullable(exception);
+        }
+    }
+
+    /**
+     * Represents an operation that is timed and returns no result, but may throw an exception.
+     */
+    @Value
+    public static class TimedWithErrorNoResult implements TimedWithError {
+        long elapsedNanos;
+        RuntimeException exception;
+
+        /**
+         * Create a new instance containing the elapsed time.
+         *
+         * @param elapsedNanos the number of nanoseconds that elapsed during the operation
+         * @return a new instance representing a successful operation
+         */
+        public static TimedWithErrorNoResult ofSuccess(long elapsedNanos) {
+            return new TimedWithErrorNoResult(elapsedNanos, null);
+        }
+
+        /**
+         * Create a new instance containing an exception.
+         *
+         * @param elapsedNanos the number of nanoseconds that elapsed during the operation
+         * @param exception the exception thrown by the operation
+         * @return a new instance representing a failed operation
+         */
+        public static TimedWithErrorNoResult ofException(long elapsedNanos, RuntimeException exception) {
+            checkArgumentNotNull(exception, "exception must not be null");
+            return new TimedWithErrorNoResult(elapsedNanos, exception);
+        }
+
+        @Override
+        public Optional<RuntimeException> getException() {
+            return Optional.ofNullable(exception);
+        }
+    }
+
+    /**
+     * Time an operation that returns a result or throws an exception.
+     * The return value should be inspected to determine whether the
+     * operation succeeded or failed.
+     *
+     * @param <R>       the type of result returned by the operation
+     * @param operation the operation to time
+     * @return a {@link TimedWithErrorOrResult} containing the elapsed time
+     * and the result of the operation or an exception if the operation failed
+     */
+    @CheckReturnValue
+    public static <R> TimedWithErrorOrResult<R> timeWithResult(Supplier<R> operation) {
+        var stopWatch = StopWatch.createStarted();
+        try {
+            var result = operation.get();
+            return TimedWithErrorOrResult.ofResult(stopWatch.getNanoTime(), result);
+        } catch (RuntimeException e) {
+            return TimedWithErrorOrResult.ofException(stopWatch.getNanoTime(), e);
+        } finally {
+            stopWatch.stop();
+        }
+    }
+
+    /**
+     * Time an operation that does not return a result, but may throw an exception.
+     * The return value should be inspected to determine whether the
+     * operation succeeded or failed.
+     *
+     * @param operation the operation to time
+     * @return a {@link TimedWithErrorNoResult} containing the elapsed time of the operation
+     * and an exception if the operation failed
+     */
+    @CheckReturnValue
+    public static TimedWithErrorNoResult timeNoResult(Runnable operation) {
+        var stopWatch = StopWatch.createStarted();
+        try {
+            operation.run();
+            return TimedWithErrorNoResult.ofSuccess(stopWatch.getNanoTime());
+        } catch (RuntimeException e) {
+            return TimedWithErrorNoResult.ofException(stopWatch.getNanoTime(), e);
+        } finally {
+            stopWatch.stop();
+        }
     }
 }

--- a/src/main/java/org/kiwiproject/beta/time/Timing.java
+++ b/src/main/java/org/kiwiproject/beta/time/Timing.java
@@ -180,7 +180,7 @@ public class Timing {
          * @return a new instance representing a successful operation
          */
         public static <R> TimedWithErrorOrResult<R> ofResult(long elapsedNanos, R result) {
-            return new TimedWithErrorOrResult<R>(elapsedNanos, result, null);
+            return new TimedWithErrorOrResult<>(elapsedNanos, result, null);
         }
 
         /**
@@ -193,7 +193,7 @@ public class Timing {
          */
         public static <R> TimedWithErrorOrResult<R> ofException(long elapsedNanos, RuntimeException exception) {
             checkArgumentNotNull(exception, "exception must not be null");
-            return new TimedWithErrorOrResult<R>(elapsedNanos, null, exception);
+            return new TimedWithErrorOrResult<>(elapsedNanos, null, exception);
         }
 
         /**

--- a/src/test/java/org/kiwiproject/beta/time/TimingTest.java
+++ b/src/test/java/org/kiwiproject/beta/time/TimingTest.java
@@ -1,16 +1,25 @@
 package org.kiwiproject.beta.time;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import org.apache.commons.lang3.time.StopWatch;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 import org.kiwiproject.base.DefaultEnvironment;
 import org.kiwiproject.base.KiwiEnvironment;
+import org.kiwiproject.beta.time.Timing.TimedWithErrorOrResult;
+import org.kiwiproject.beta.time.Timing.TimedWithErrorNoResult;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 @DisplayName("Timing")
@@ -18,63 +27,264 @@ class TimingTest {
 
     private static final KiwiEnvironment ENV = new DefaultEnvironment();
 
-    private StopWatch stopWatch;
+    @Nested
+    class WithExplicitStopWatch {
 
-    @BeforeEach
-    void setUp() {
-        stopWatch = new StopWatch();
+        private StopWatch stopWatch;
+
+        @BeforeEach
+        void setUp() {
+            stopWatch = new StopWatch();
+        }
+
+        @RepeatedTest(10)
+        void shouldTimeOperationsThatReturnResult() {
+            Supplier<Integer> op = () -> {
+                sleepSmallRandomTime();
+                return 42 * 42;
+            };
+            var result = Timing.timeWithResult(stopWatch, op);
+
+            assertAll(
+                    () -> assertThat(result.getElapsedMillis()).isPositive(),
+                    () -> assertThat(result.getResult()).isEqualTo(1764),
+                    () -> assertThat(stopWatch.isStopped()).isTrue(),
+                    () -> assertThat(stopWatch.getTime()).isEqualTo(result.getElapsedMillis())
+            );
+        }
+
+        @RepeatedTest(10)
+        void shouldStopStopWatch_WhenExceptionsAreThrown_FromTimedOperationWithResult() {
+            Supplier<Integer> op = () -> {
+                sleepSmallRandomTime();
+                throw new RuntimeException("oops");
+            };
+
+            assertAll(
+                    () -> assertThatThrownBy(() -> Timing.timeWithResult(stopWatch, op))
+                            .isExactlyInstanceOf(RuntimeException.class)
+                            .hasMessage("oops"),
+                    () -> assertThat(stopWatch.isStopped()).isTrue(),
+                    () -> assertThat(stopWatch.getTime()).isPositive()
+            );
+        }
+
+        @RepeatedTest(10)
+        void shouldTimeOperationsThatDoNotReturnResult() {
+            Runnable op = TimingTest::sleepSmallRandomTime;
+            var result = Timing.timeNoResult(stopWatch, op);
+
+            assertAll(
+                    () -> assertThat(result.getElapsedMillis()).isPositive(),
+                    () -> assertThat(stopWatch.isStopped()).isTrue(),
+                    () -> assertThat(stopWatch.getTime()).isEqualTo(result.getElapsedMillis())
+            );
+        }
+
+        @RepeatedTest(10)
+        void shouldStopStopWatch_WhenExceptionsAreThrown_FromTimedOperationWithNoResult() {
+            Runnable op = () -> {
+                sleepSmallRandomTime();
+                throw new RuntimeException("ugh");
+            };
+
+            assertAll(
+                    () -> assertThatThrownBy(() -> Timing.timeNoResult(stopWatch, op))
+                            .isExactlyInstanceOf(RuntimeException.class)
+                            .hasMessage("ugh"),
+                    () -> assertThat(stopWatch.isStopped()).isTrue(),
+                    () -> assertThat(stopWatch.getTime()).isPositive()
+            );
+        }
     }
 
-    @RepeatedTest(10)
-    void shouldTimeOperationsThatReturnResult() {
-        Supplier<Integer> op = () -> {
-            sleepSmallRandomTime();
-            return 42 * 42;
-        };
-        var result = Timing.timeWithResult(stopWatch, op);
+    @Nested
+    class TimedWithErrorOrResultClass {
 
-        assertThat(result.getElapsedMillis()).isPositive();
-        assertThat(result.getResult()).isEqualTo(1764);
-        assertThat(stopWatch.isStopped()).isTrue();
-        assertThat(stopWatch.getTime()).isEqualTo(result.getElapsedMillis());
+        @Test
+        void shouldThrowIllegalArgument_WhenBothConstructorArgsAreNotNull() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> new TimedWithErrorOrResult<String>(42_000_000L, "the result", new RuntimeException()))
+                    .withMessage("Cannot contain a result and an exception");
+        }
+
+        @Test
+        void shouldThrowIllegalArgument_WhenNullExceptionIsProvided() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> TimedWithErrorOrResult.ofException(42_000_000L, null))
+                    .withMessage("exception must not be null");
+        }
+
+        @Test
+        void shouldCreateWithNonNullResult() {
+            var result = new TimedWithErrorOrResult<>(42_000_000L, "the result", null);
+
+            assertAll(
+                () -> assertThat(result.getElapsedNanos()).isEqualTo(42_000_000L),
+                () -> assertThat(result.getElapsedMillis()).isEqualTo(42L),
+                () -> assertThat(result.operationSucceeded()).isTrue(),
+                () -> assertThat(result.hasResult()).isTrue(),
+                () -> assertThat(result.isNullResult()).isFalse(),
+                () -> assertThat(result.getResult()).contains("the result"),
+                () -> assertThat(result.hasException()).isFalse(),
+                () -> assertThat(result.getException()).isEmpty()
+            );
+        }
+
+        @Test
+        void shouldCreateWithNullResult() {
+            var result = new TimedWithErrorOrResult<>(420_000_000L, null, null);
+
+            assertAll(
+                () -> assertThat(result.getElapsedNanos()).isEqualTo(420_000_000L),
+                () -> assertThat(result.getElapsedMillis()).isEqualTo(420L),
+                () -> assertThat(result.operationSucceeded()).isTrue(),
+                () -> assertThat(result.hasResult()).isTrue(),
+                () -> assertThat(result.isNullResult()).isTrue(),
+                () -> assertThat(result.getResult()).isEmpty(),
+                () -> assertThat(result.hasException()).isFalse(),
+                () -> assertThat(result.getException()).isEmpty()
+            );
+        }
+
+        @Test
+        void shouldCreateWithException() {
+            var error = new UncheckedIOException(new IOException("disk full"));
+            var result = new TimedWithErrorOrResult<>(126_000_000L, null, error);
+
+            assertAll(
+                () -> assertThat(result.getElapsedMillis()).isEqualTo(126L),
+                () -> assertThat(result.operationSucceeded()).isFalse(),
+                () -> assertThat(result.hasResult()).isFalse(),
+                () -> assertThat(result.isNullResult()).isFalse(),
+                () -> assertThat(result.getResult()).isEmpty(),
+                () -> assertThat(result.hasException()).isTrue(),
+                () -> assertThat(result.getException()).contains(error)
+            );
+        }
     }
 
-    @RepeatedTest(10)
-    void shouldStopStopWatch_WhenExceptionsAreThrown_FromTimedOperationWithResult() {
-        Supplier<Integer> op = () -> {
-            sleepSmallRandomTime();
-            throw new RuntimeException("oops");
-        };
+    @Nested
+    class TimedWithErrorNoResultClass {
 
-        assertThatThrownBy(() -> Timing.timeWithResult(stopWatch, op))
-                .isExactlyInstanceOf(RuntimeException.class)
-                .hasMessage("oops");
-        assertThat(stopWatch.isStopped()).isTrue();
-        assertThat(stopWatch.getTime()).isPositive();
+        @Test
+        void shouldCreateWithoutException() {
+            var result = TimedWithErrorNoResult.ofSuccess(42_000_000L);
+
+            assertAll(
+                () -> assertThat(result.getElapsedNanos()).isEqualTo(42_000_000L),
+                () -> assertThat(result.getElapsedMillis()).isEqualTo(42L),
+                () -> assertThat(result.operationSucceeded()).isTrue(),
+                () -> assertThat(result.hasException()).isFalse(),
+                () -> assertThat(result.getException()).isEmpty()
+            );
+        }
+
+        @Test
+        void shouldCreateWithException() {
+            var error = new UncheckedIOException(new IOException("broken pipe"));
+            var result = TimedWithErrorNoResult.ofException(420_000_000L, error);
+
+            assertAll(
+                () -> assertThat(result.getElapsedNanos()).isEqualTo(420_000_000L),
+                () -> assertThat(result.getElapsedMillis()).isEqualTo(420L),
+                () -> assertThat(result.operationSucceeded()).isFalse(),
+                () -> assertThat(result.hasException()).isTrue(),
+                () -> assertThat(result.getException()).contains(error)
+            );
+        }
+
+        @Test
+        void shouldThrowIllegalArgument_WhenNullExceptionIsProvided() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> TimedWithErrorNoResult.ofException(42_000_000L, null))
+                    .withMessage("exception must not be null");
+        }
     }
 
-    @RepeatedTest(10)
-    void shouldTimeOperationsThatDoNotReturnResult() {
-        Runnable op = TimingTest::sleepSmallRandomTime;
-        var result = Timing.timeNoResult(stopWatch, op);
+    @Nested
+    class WithInternalStopWatch {
 
-        assertThat(result.getElapsedMillis()).isPositive();
-        assertThat(stopWatch.isStopped()).isTrue();
-        assertThat(stopWatch.getTime()).isEqualTo(result.getElapsedMillis());
-    }
+        @RepeatedTest(10)
+        void shouldTimeOperationsThatReturnResult() {
+            Supplier<Integer> op = () -> {
+                sleepSmallRandomTime();
+                return 42 * 42;
+            };
+            var result = Timing.timeWithResult(op);
 
-    @RepeatedTest(10)
-    void shouldStopStopWatch_WhenExceptionsAreThrown_FromTimedOperationWithNoResult() {
-        Runnable op = () -> {
-            sleepSmallRandomTime();
-            throw new RuntimeException("ugh");
-        };
+            assertAll(
+                    () -> assertThat(result.getElapsedNanos()).isPositive(),
+                    () -> assertThat(result.getElapsedMillis())
+                            .isEqualTo(TimeUnit.NANOSECONDS.toMillis(result.getElapsedNanos())),
+                    () -> assertThat(result.getElapsedMillis()).isPositive(),
+                    () -> assertThat(result.operationSucceeded()).isTrue(),
+                    () -> assertThat(result.hasResult()).isTrue(),
+                    () -> assertThat(result.getResult()).contains(1764),
+                    () -> assertThat(result.hasException()).isFalse(),
+                    () -> assertThat(result.getException()).isEmpty()
+            );
+        }
 
-        assertThatThrownBy(() -> Timing.timeNoResult(stopWatch, op))
-                .isExactlyInstanceOf(RuntimeException.class)
-                .hasMessage("ugh");
-        assertThat(stopWatch.isStopped()).isTrue();
-        assertThat(stopWatch.getTime()).isPositive();
+        @RepeatedTest(10)
+        void shouldTimedOperationsThatThrowException() {
+            var exception = new RuntimeException("oops");
+            Supplier<Integer> op = () -> {
+                sleepSmallRandomTime();
+                throw exception;
+            };
+
+            var result = Timing.timeWithResult(op);
+
+            assertAll(
+                () -> assertThat(result.getElapsedNanos()).isPositive(),
+                () -> assertThat(result.getElapsedMillis())
+                        .isEqualTo(TimeUnit.NANOSECONDS.toMillis(result.getElapsedNanos())),
+                () -> assertThat(result.getElapsedMillis()).isPositive(),
+                () -> assertThat(result.operationSucceeded()).isFalse(),
+                () -> assertThat(result.hasResult()).isFalse(),
+                () -> assertThat(result.getResult()).isEmpty(),
+                () -> assertThat(result.hasException()).isTrue(),
+                () -> assertThat(result.getException()).contains(exception)
+            );
+        }
+
+        @RepeatedTest(10)
+        void shouldTimeOperationsThatDoNotReturnResult() {
+            Runnable op = TimingTest::sleepSmallRandomTime;
+            var result = Timing.timeNoResult(op);
+
+            assertAll(
+                    () -> assertThat(result.getElapsedNanos()).isPositive(),
+                    () -> assertThat(result.getElapsedMillis())
+                            .isEqualTo(TimeUnit.NANOSECONDS.toMillis(result.getElapsedNanos())),
+                    () -> assertThat(result.getElapsedMillis()).isPositive(),
+                    () -> assertThat(result.operationSucceeded()).isTrue(),
+                    () -> assertThat(result.hasException()).isFalse(),
+                    () -> assertThat(result.getException()).isEmpty()
+            );
+        }
+
+        @RepeatedTest(10)
+        void shouldStopStopWatch_WhenExceptionsAreThrown_FromTimedOperationWithNoResult() {
+            var exception = new RuntimeException("ugh");
+            Runnable op = () -> {
+                sleepSmallRandomTime();
+                throw exception;
+            };
+
+            var result = Timing.timeNoResult(op);
+
+            assertAll(
+                    () -> assertThat(result.getElapsedNanos()).isPositive(),
+                    () -> assertThat(result.getElapsedMillis())
+                            .isEqualTo(TimeUnit.NANOSECONDS.toMillis(result.getElapsedNanos())),
+                    () -> assertThat(result.getElapsedMillis()).isPositive(),
+                    () -> assertThat(result.operationSucceeded()).isFalse(),
+                    () -> assertThat(result.hasException()).isTrue(),
+                    () -> assertThat(result.getException()).contains(exception)
+            );
+        }
     }
 
     private static void sleepSmallRandomTime() {


### PR DESCRIPTION
Add several new methods to Timing which do not require a StopWatch. This required new "result" classes, because any exceptions must be caught instead of thrown, so that callers can retrieve elapsed time even if an exception occurs.

The new methods and result types provide nanosecond timing instead of just milliseonds, like the original methods in this class do.

The new result types are the sealed interface TimedWithError and its two implementations, TimedWithErrorOrResult and TimedWithErrorNoResult.

The new timeWithResult and timeNoResult methods are annotated with the error prone CheckReturnValue annotation, to make it clear that it must be inspected to get the elapsed time and result or exception (though it seems like it should be pretty obvious).

Changed the original Timed interfaced to be sealed and to permit only TimedWithResult and TimedNoResult, since no one else should be creating subclasses.

Also made a few minor javadoc changes to the original methods.