### PR TITLE
Replace deprecated API usage in Timing

### DIFF
--- a/src/main/java/org/kiwiproject/beta/time/Timing.java
+++ b/src/main/java/org/kiwiproject/beta/time/Timing.java
@@ -171,7 +171,7 @@ public class Timing {
      * throws an exception.
      * <p>
      * If you need the elapsed time when an exception is thrown, you can simply call
-     * {@link StopWatch#getTime()} or {@link StopWatch#getNanoTime()}.
+     * {@link StopWatch#getDuration()} or {@link StopWatch#getNanoTime()}.
      * <p>
      * Since {@link StopWatch} is not thread-safe, callers are responsible for ensuring
      * thread-safety. Passing it as an argument permits timing more than one sequential operation
@@ -204,7 +204,7 @@ public class Timing {
      * throws an exception.
      * <p>
      * If you need the elapsed time when an exception is thrown, you can simply call
-     * {@link StopWatch#getTime()} or {@link StopWatch#getNanoTime()}.
+     * {@link StopWatch#getDuration()} or {@link StopWatch#getNanoTime()}.
      * <p>
      * Since {@link StopWatch} is not thread-safe, callers are responsible for ensuring
      * thread-safety. Passing it as an argument permits timing more than one sequential operation

--- a/src/test/java/org/kiwiproject/beta/time/TimingTest.java
+++ b/src/test/java/org/kiwiproject/beta/time/TimingTest.java
@@ -51,7 +51,7 @@ class TimingTest {
                     () -> assertThat(result.getElapsedMillis()).isPositive(),
                     () -> assertThat(result.getResult()).isEqualTo(1764),
                     () -> assertThat(stopWatch.isStopped()).isTrue(),
-                    () -> assertThat(stopWatch.getTime()).isEqualTo(result.getElapsedMillis())
+                    () -> assertThat(stopWatch.getDuration().toMillis()).isEqualTo(result.getElapsedMillis())
             );
         }
 
@@ -67,7 +67,7 @@ class TimingTest {
                             .isExactlyInstanceOf(RuntimeException.class)
                             .hasMessage("oops"),
                     () -> assertThat(stopWatch.isStopped()).isTrue(),
-                    () -> assertThat(stopWatch.getTime()).isPositive()
+                    () -> assertThat(stopWatch.getDuration()).isPositive()
             );
         }
 
@@ -79,7 +79,7 @@ class TimingTest {
             assertAll(
                     () -> assertThat(result.getElapsedMillis()).isPositive(),
                     () -> assertThat(stopWatch.isStopped()).isTrue(),
-                    () -> assertThat(stopWatch.getTime()).isEqualTo(result.getElapsedMillis())
+                    () -> assertThat(stopWatch.getDuration().toMillis()).isEqualTo(result.getElapsedMillis())
             );
         }
 
@@ -95,7 +95,7 @@ class TimingTest {
                             .isExactlyInstanceOf(RuntimeException.class)
                             .hasMessage("ugh"),
                     () -> assertThat(stopWatch.isStopped()).isTrue(),
-                    () -> assertThat(stopWatch.getTime()).isPositive()
+                    () -> assertThat(stopWatch.getDuration()).isPositive()
             );
         }
     }


### PR DESCRIPTION
The recent commons-lang3 version 3.17.0 release deprecated StopWatch#getTime. You are now supposed to use #getDuration.