### PR TITLE
Add JarManifestHelper as an instance-based alternative to JarManifests

### DIFF
--- a/src/main/java/org/kiwiproject/beta/base/jar/AttributeLookupResult.java
+++ b/src/main/java/org/kiwiproject/beta/base/jar/AttributeLookupResult.java
@@ -1,0 +1,73 @@
+package org.kiwiproject.beta.base.jar;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.nonNull;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentIsNull;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Optional;
+
+/**
+ * A record that contains a lookup status and, if the lookup succeeded, a value.
+ *
+ * @param lookupStatus the lookup status
+ * @param value        the value, or null if the lookup did not succeed for any reason
+ * @param error        the Exception that occurred during a failed lookup, or null if the cause was not an exception
+ */
+public record AttributeLookupResult(AttributeLookupStatus lookupStatus,
+                                    @Nullable String value,
+                                    @Nullable Exception error) {
+
+    public AttributeLookupResult {
+        if (lookupStatus == AttributeLookupStatus.EXISTS) {
+            checkArgumentNotNull(value, "value must not be null when lookup succeeds");
+            checkArgumentIsNull(error, "error must be null when lookup succeeds");
+        } else {
+            checkArgumentIsNull(value, "value must be null when lookup fails");
+        }
+    }
+
+    /**
+     * @return true if the lookup failed for any reason, otherwise true
+     */
+    public boolean failed() {
+        return !succeeded();
+    }
+
+    /**
+     * Check if the lookup succeeded; a successful lookup occurs only when
+     * the attribute exists and has a value.
+     *
+     * @return true if the lookup succeeded, otherwise false
+     */
+    public boolean succeeded() {
+        return lookupStatus == AttributeLookupStatus.EXISTS;
+    }
+
+    /**
+     * @return true if, and only if, the value is not null
+     */
+    public boolean containsValue() {
+        return nonNull(value);
+    }
+
+    /**
+     * @return an Optional wrapping the value
+     */
+    public Optional<String> maybeValue() {
+        return Optional.ofNullable(value);
+    }
+
+    /**
+     * Return the attribute value if non-null. Otherwise, throw an {@link IllegalStateException}.
+     *
+     * @return the value if not-null
+     * @throws IllegalStateException if value is null
+     */
+    public String valueOrThrow() {
+        checkState(nonNull(value), "expected value not to be null");
+        return value;
+    }
+}

--- a/src/main/java/org/kiwiproject/beta/base/jar/AttributeLookupStatus.java
+++ b/src/main/java/org/kiwiproject/beta/base/jar/AttributeLookupStatus.java
@@ -1,0 +1,22 @@
+package org.kiwiproject.beta.base.jar;
+
+/**
+ * Represents the result of an attribute lookup.
+ */
+public enum AttributeLookupStatus {
+
+    /**
+     * The attribute exists.
+     */
+    EXISTS,
+
+    /**
+     * The attribute does not exist.
+     */
+    DOES_NOT_EXIST,
+
+    /**
+     * An I/O or other error occurred retrieving the attribute.
+     */
+    FAILURE
+}

--- a/src/main/java/org/kiwiproject/beta/base/jar/AttributesLookupResult.java
+++ b/src/main/java/org/kiwiproject/beta/base/jar/AttributesLookupResult.java
@@ -1,0 +1,59 @@
+package org.kiwiproject.beta.base.jar;
+
+import static java.util.Objects.nonNull;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentIsNull;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A record that contains a lookup status and, if the lookup succeeded, a map of all the attributes.
+ *
+ * @param lookupStatus the lookup status
+ * @param attributes   a map containing the attributes, or null if the lookup failed for any reason
+ * @param error        the Exception that occurred during a failed lookup, or null if the cause was not an exception
+ */
+public record AttributesLookupResult(AttributesLookupStatus lookupStatus,
+                                     @Nullable Map<String, String> attributes,
+                                     @Nullable Exception error) {
+
+    public AttributesLookupResult {
+        if (lookupStatus == AttributesLookupStatus.SUCCESS) {
+            checkArgumentNotNull(attributes, "attributes must not be null when lookup succeeds");
+            checkArgumentIsNull(error, "error must be null when lookup succeeds");
+        } else {
+            checkArgumentIsNull(attributes, "attributes must be null when lookup fails");
+        }
+    }
+
+    /**
+     * @return true if the lookup failed for any reason, otherwise true
+     */
+    public boolean failed() {
+        return !succeeded();
+    }
+
+    /**
+     * @return true if the lookup succeeded, otherwise false
+     */
+    public boolean succeeded() {
+        return lookupStatus == AttributesLookupStatus.SUCCESS;
+    }
+
+    /**
+     * @return true if, and only if, attributes is not null
+     */
+    public boolean hasAttributes() {
+        return nonNull(attributes);
+    }
+
+    /**
+     * @return an Optional wrapping the attributes
+     */
+    public Optional<Map<String, String>> maybeAttributes() {
+        return Optional.ofNullable(attributes);
+    }
+}

--- a/src/main/java/org/kiwiproject/beta/base/jar/AttributesLookupStatus.java
+++ b/src/main/java/org/kiwiproject/beta/base/jar/AttributesLookupStatus.java
@@ -1,0 +1,17 @@
+package org.kiwiproject.beta.base.jar;
+
+/**
+ * Represents the result of looking up all attributes.
+ */
+public enum AttributesLookupStatus {
+
+    /**
+     * The lookup returned attributes.
+     */
+    SUCCESS,
+
+    /**
+     * An I/O or other error occurred retrieving the attributes.
+     */
+    FAILURE
+}

--- a/src/main/java/org/kiwiproject/beta/base/jar/JarManifestHelper.java
+++ b/src/main/java/org/kiwiproject/beta/base/jar/JarManifestHelper.java
@@ -1,0 +1,131 @@
+package org.kiwiproject.beta.base.jar;
+
+import com.google.common.annotations.Beta;
+import com.google.errorprone.annotations.CheckReturnValue;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Optional;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+
+/**
+ * Utilities for working with JAR manifests.
+ * <p>
+ * Unlike {@link JarManifests}, this is an instance-based class, which allows
+ * for easier testing using techniques such as mocking. In addition, some methods
+ * in this class return "result" objects, which contain more information than
+ * an Optional can convey.
+ *
+ * @see Manifest
+ * @see JarManifests
+ */
+@Beta
+public class JarManifestHelper {
+
+    /**
+     * Get the main attribute value in a Manifest, using the given Class to locate the
+     * associated {@code MANIFEST.MF} file.
+     *
+     * @param theClass the Class to use for finding the Manifest
+     * @param name     the name of the main attribute
+     * @return a lookup result
+     */
+    @CheckReturnValue
+    public AttributeLookupResult getMainAttributeValue(Class<?> theClass, String name) {
+        try {
+            var manifest = JarManifests.getManifestOrThrow(theClass);
+            return getMainAttributeValue(manifest, name);
+        } catch (Exception e) {
+            return new AttributeLookupResult(AttributeLookupStatus.FAILURE, null, e);
+        }
+    }
+
+    /**
+     * Get the main attribute value in a Manifest having the given name.
+     *
+     * @param manifest the Manifest
+     * @param name     the name of the main attribute
+     * @return a lookup result
+     */
+    @CheckReturnValue
+    public AttributeLookupResult getMainAttributeValue(Manifest manifest, String name) {
+        var attributes = manifest.getMainAttributes();
+        if (!attributes.containsKey(new Attributes.Name(name))) {
+            return new AttributeLookupResult(AttributeLookupStatus.DOES_NOT_EXIST, null, null);
+        }
+
+        var value = attributes.getValue(name);
+        return new AttributeLookupResult(AttributeLookupStatus.EXISTS, value, null);
+    }
+
+    /**
+     * Return the main attributes of the Manifest, using the given Class to locate the
+     * associated {@code MANIFEST.MF} file.
+     *
+     * @param theClass the Class to use for finding the Manifest
+     * @return a lookup result
+     */
+    public AttributesLookupResult getMainAttributes(Class<?> theClass) {
+        var lookupResult = getManifestWithResult(theClass);
+
+        return switch (lookupResult.lookupStatus()) {
+            case SUCCESS -> {
+                var mainAttributes = getMainAttributes(lookupResult.manifestOrThrow());
+                yield new AttributesLookupResult(AttributesLookupStatus.SUCCESS, mainAttributes, null);
+            }
+            case FAILURE -> new AttributesLookupResult(AttributesLookupStatus.FAILURE, null, lookupResult.error());
+        };
+    }
+
+    /**
+     * Return the main attributes of the given Manifest as a Map of String keys to String values.
+     *
+     * @param manifest the manifest
+     * @return a map containing the main attributes
+     */
+    public Map<String, String> getMainAttributes(Manifest manifest) {
+        return JarManifests.getMainAttributesAsMap(manifest);
+    }
+
+    /**
+     * Use the given Class to locate the associated {@code MANIFEST.MF} file.
+     *
+     * @param theClass the Class to use for finding the Manifest
+     * @return an Optional containing the Manifest, or an empty Optional if any error occurs
+     */
+    public Optional<Manifest> getManifest(Class<?> theClass) {
+        return JarManifests.getManifest(theClass);
+    }
+
+    /**
+     * Use the given Class to locate the associated {@code MANIFEST.MF} file.
+     *
+     * @param theClass the Class to use for finding the Manifest
+     * @return a {@link ManifestLookupResult} containing information about the lookup
+     */
+    public ManifestLookupResult getManifestWithResult(Class<?> theClass) {
+        var classHolder = new JarManifests.ClassHolder(theClass);
+        return JarManifests.getManifest(classHolder);
+    }
+
+    /**
+     * Use the given URI to locate the associated {@code MANIFEST.MF} file.
+     *
+     * @param jarFileURI the URI of the JAR file in which the manifest resides
+     * @return an Optional containing the Manifest, or an empty Optional if any error occurs
+     */
+    public Optional<Manifest> getManifest(URI jarFileURI) {
+        return JarManifests.getManifest(jarFileURI);
+    }
+
+    /**
+     * Use the given URI to locate the associated {@code MANIFEST.MF} file.
+     *
+     * @param jarFileURI the URI of the JAR file in which the manifest resides
+     * @return a {@link ManifestLookupResult} containing information about the lookup
+     */
+    public ManifestLookupResult getManifestWithResult(URI jarFileURI) {
+        return JarManifests.getManifestWithResult(jarFileURI);
+    }
+}

--- a/src/main/java/org/kiwiproject/beta/base/jar/JarManifests.java
+++ b/src/main/java/org/kiwiproject/beta/base/jar/JarManifests.java
@@ -6,7 +6,6 @@ import static org.kiwiproject.base.KiwiStrings.f;
 
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.VisibleForTesting;
-
 import lombok.AllArgsConstructor;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
@@ -23,35 +22,78 @@ import java.util.jar.Manifest;
 
 /**
  * Static utilities related to JAR manifests.
+ * <p>
+ * If you need to be able to mock the functionality in this class
+ * for testing, consider using {@link JarManifestHelper} instead.
  *
  * @see Manifest
+ * @see JarManifestHelper
  */
 @UtilityClass
 @Beta
 @Slf4j
 public class JarManifests {
 
+    /**
+     * Get the main attribute value in a Manifest, using the given Class to locate the
+     * associated {@code MANIFEST.MF} file.
+     *
+     * @param theClass the Class to use for finding the Manifest
+     * @param name     the name of the main attribute
+     * @return the value of the attribute
+     * @throws IllegalStateException if the lookup failed or the attribute does not exist
+     */
     public static String getMainAttributeValueOrThrow(Class<?> theClass, String name) {
         return getMainAttributeValue(theClass, name).orElseThrow(
                 () -> new IllegalStateException(f("Unable to get value for main attribute {} for {}", name, theClass)));
     }
 
+    /**
+     * Get the main attribute value in a Manifest, using the given Class to locate the
+     * associated {@code MANIFEST.MF} file.
+     *
+     * @param theClass the Class to use for finding the Manifest
+     * @param name     the name of the main attribute
+     * @return an Optional containing the value, or an empty Optional if the looked failed
+     */
     public static Optional<String> getMainAttributeValue(Class<?> theClass, String name) {
         return getManifest(theClass)
                 .map(manifest -> getMainAttributeValue(manifest, name))
                 .flatMap(Function.identity());
     }
 
+    /**
+     * Get the main attribute value in a Manifest having the given name.
+     *
+     * @param manifest the Manifest
+     * @param name     the name of the main attribute
+     * @return an Optional containing the value, or an empty Optional if the lookup failed
+     */
     public static Optional<String> getMainAttributeValue(Manifest manifest, String name) {
         var value = manifest.getMainAttributes().getValue(name);
         return Optional.ofNullable(value);
     }
 
+    /**
+     * Return the main attributes of the Manifest, using the given Class to locate the
+     * associated {@code MANIFEST.MF} file.
+     *
+     * @param theClass the Class to use for finding the Manifest
+     * @return a map containing the main attributes
+     * @throws IllegalStateException if the lookup fails for any reason
+     */
     public static Map<String, String> getMainAttributesAsMapOrThrow(Class<?> theClass) {
         var manifest = getManifestOrThrow(theClass);
         return getMainAttributesAsMap(manifest);
     }
 
+    /**
+     * Return the main attributes of the Manifest, using the given Class to locate the
+     * associated {@code MANIFEST.MF} file.
+     *
+     * @param manifest the manifest
+     * @return a map containing the main attributes
+     */
     public static Map<String, String> getMainAttributesAsMap(Manifest manifest) {
         return manifest.getMainAttributes()
                 .entrySet()
@@ -59,14 +101,42 @@ public class JarManifests {
                 .collect(toUnmodifiableMap(e -> String.valueOf(e.getKey()), e -> String.valueOf(e.getValue())));
     }
 
+    /**
+     * Use the given Class to locate the associated {@code MANIFEST.MF} file.
+     *
+     * @param theClass the Class to use for finding the Manifest
+     * @return the Manifest
+     * @throws IllegalStateException if the lookup fails for any reason
+     */
     public static Manifest getManifestOrThrow(Class<?> theClass) {
-        return getManifest(theClass)
-                .orElseThrow(() -> new IllegalStateException("Unable to get manifest for " + theClass));
+        var classHolder = new ClassHolder(theClass);
+        var lookupResult = getManifest(classHolder);
+
+        return switch (lookupResult.lookupStatus()) {
+            case SUCCESS -> lookupResult.manifestOrThrow();
+            case FAILURE -> throw illegalStateExceptionFor(lookupResult, theClass);
+        };
     }
 
+    private static IllegalStateException illegalStateExceptionFor(ManifestLookupResult lookupResult,
+                                                                  Class<?> theClass) {
+
+        var errorMessage = "Unable to get manifest for " + theClass;
+        return Optional.ofNullable(lookupResult.error())
+                .map(error -> new IllegalStateException(errorMessage, error))
+                .orElseGet(() -> new IllegalStateException(errorMessage));
+    }
+
+    /**
+     * Use the given Class to locate the associated {@code MANIFEST.MF} file.
+     *
+     * @param theClass the Class to use for finding the Manifest
+     * @return an Optional containing the Manifest, or an empty Optional if the lookup failed
+     */
     public static Optional<Manifest> getManifest(Class<?> theClass) {
         var classHolder = new ClassHolder(theClass);
-        return getManifest(classHolder);
+        var lookupResult = getManifest(classHolder);
+        return lookupResult.maybeManifest();
     }
 
     /**
@@ -75,27 +145,38 @@ public class JarManifests {
      * ProtectionDomain is not final, but its getCodeSource() method is, so it also cannot
      * be mocked.
      */
-    @VisibleForTesting
-    static Optional<Manifest> getManifest(ClassHolder holder) {
+    static ManifestLookupResult getManifest(ClassHolder holder) {
         var theClass = holder.getContainedClass();
         try {
+            String errorMessage;
             var codeSource = holder.getProtectionDomain().getCodeSource();
             if (nonNull(codeSource)) {
                 var location = codeSource.getLocation();
                 LOG.trace("CodeSource location of {}: {}", theClass, location);
                 if (nonNull(location)) {
-                    return getManifest(location.toURI());
+                    return getManifestWithResult(location.toURI());
+                } else {
+                    errorMessage = f("The Location of the CodeSource was null. CodeSource: {}", codeSource);
                 }
+            } else {
+                errorMessage = "The CodeSource from the ProtectionDomain was null";
             }
 
-            LOG.warn("Unable to get manifest of JAR file for {}", theClass);
-            return Optional.empty();
+            LOG.warn("Unable to get manifest of JAR file for {}, cause: {}", theClass, errorMessage);
+            return new ManifestLookupResult(ManifestLookupStatus.FAILURE, null, null, errorMessage);
         } catch (Exception e) {
             LOG.error("Error getting manifest of JAR for {}", theClass, e);
-            return Optional.empty();
+            return new ManifestLookupResult(ManifestLookupStatus.FAILURE, null, e, null);
         }
     }
 
+    /**
+     * This class is entirely to permit testing error conditions which
+     * cannot otherwise be easily tested using the JDK classes directly.
+     * <p>
+     * For example, to allow simulating a {@link SecurityException} thrown
+     * when calling {@link Class#getProtectionDomain()}.
+     */
     @VisibleForTesting
     @AllArgsConstructor
     static class ClassHolder {
@@ -110,12 +191,24 @@ public class JarManifests {
         }
     }
 
+    /**
+     * Use the given URI to locate the associated {@code MANIFEST.MF} file.
+     *
+     * @param jarFileURI the URI of the JAR file in which the manifest resides
+     * @return an Optional containing the Manifest, or an empty Optional if any error occurs
+     */
     public static Optional<Manifest> getManifest(URI jarFileURI) {
+        var lookupResult = getManifestWithResult(jarFileURI);
+        return lookupResult.maybeManifest();
+    }
+
+    static ManifestLookupResult getManifestWithResult(URI jarFileURI) {
         try (var jarFile = new JarFile(new File(jarFileURI))) {
-            return Optional.of(jarFile.getManifest());
+            var manifest = jarFile.getManifest();
+            return new ManifestLookupResult(ManifestLookupStatus.SUCCESS, manifest, null, null);
         } catch (IOException e) {
             LOG.error("Error getting manifest of JAR for URI {}", jarFileURI, e);
-            return Optional.empty();
+            return new ManifestLookupResult(ManifestLookupStatus.FAILURE, null, e, null);
         }
     }
 }

--- a/src/main/java/org/kiwiproject/beta/base/jar/ManifestLookupResult.java
+++ b/src/main/java/org/kiwiproject/beta/base/jar/ManifestLookupResult.java
@@ -1,0 +1,67 @@
+package org.kiwiproject.beta.base.jar;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.nonNull;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentIsNull;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Optional;
+import java.util.jar.Manifest;
+
+/**
+ * A record that contains lookup status and, if the lookup succeeded, a {@link Manifest}.
+ *
+ * @param lookupStatus the lookup status
+ * @param manifest     the Manifest, or null if the lookup failed for any reason
+ * @param error        the Exception that occurred during a failed lookup, or null if the cause was not an exception
+ * @param errorMessage an error message describing the cause of the lookup failure
+ */
+public record ManifestLookupResult(ManifestLookupStatus lookupStatus,
+                                   @Nullable Manifest manifest,
+                                   @Nullable Exception error,
+                                   @Nullable String errorMessage) {
+
+    public ManifestLookupResult {
+        if (lookupStatus == ManifestLookupStatus.SUCCESS) {
+            checkArgumentNotNull(manifest, "manifest must not be null when lookup succeeds");
+            checkArgumentIsNull(error, "error must be null when lookup succeeds");
+            checkArgumentIsNull(errorMessage, "error must be null when lookup succeeds");
+        } else {
+            checkArgumentIsNull(manifest, "manifest must be null when lookup fails");
+        }
+    }
+
+    /**
+     * @return true if the lookup failed for any reason, otherwise true
+     */
+    public boolean failed() {
+        return !succeeded();
+    }
+
+    /**
+     * @return true if the lookup succeeded, otherwise false
+     */
+    public boolean succeeded() {
+        return lookupStatus == ManifestLookupStatus.SUCCESS;
+    }
+
+    /**
+     * @return an Optional wrapping the manifest
+     */
+    public Optional<Manifest> maybeManifest() {
+        return Optional.ofNullable(manifest);
+    }
+
+    /**
+     * Return the Manifest if non-null. Otherwise, throw an {@link IllegalStateException}.
+     *
+     * @return the manifest if not-null
+     * @throws IllegalStateException if the Manifest is null
+     */
+    public Manifest manifestOrThrow() {
+        checkState(nonNull(manifest), "expected manifest not to be null");
+        return manifest;
+    }
+}

--- a/src/main/java/org/kiwiproject/beta/base/jar/ManifestLookupStatus.java
+++ b/src/main/java/org/kiwiproject/beta/base/jar/ManifestLookupStatus.java
@@ -1,0 +1,6 @@
+package org.kiwiproject.beta.base.jar;
+
+public enum ManifestLookupStatus {
+    SUCCESS,
+    FAILURE
+}

--- a/src/test/java/org/kiwiproject/beta/base/jar/AttributeLookupResultTest.java
+++ b/src/test/java/org/kiwiproject/beta/base/jar/AttributeLookupResultTest.java
@@ -1,0 +1,66 @@
+package org.kiwiproject.beta.base.jar;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+
+@DisplayName("AttributeLookupResult")
+class AttributeLookupResultTest {
+
+    @ParameterizedTest
+    @EnumSource(value = AttributeLookupStatus.class, names = "EXISTS", mode = EnumSource.Mode.EXCLUDE)
+    void shouldRequireNullValue_WhenLookupFails(AttributeLookupStatus lookupStatus) {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new AttributeLookupResult(lookupStatus, "a value", null))
+                .withMessage("value must be null when lookup fails");
+    }
+
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+            EXISTS, some-value, true
+            DOES_NOT_EXIST, null, false
+            FAILURE, null, false
+            """, nullValues = "null")
+    void shouldHaveConsistentSucceededAndFailed(AttributeLookupStatus lookupStatus,
+                                                String value,
+                                                boolean expectedSuccessValue) {
+
+        var result = new AttributeLookupResult(lookupStatus, value, null);
+
+        assertAll(
+                () -> assertThat(result.succeeded()).isEqualTo(expectedSuccessValue),
+                () -> assertThat(result.failed()).isNotEqualTo(result.succeeded()),
+                () -> assertThat(result.containsValue()).isEqualTo(expectedSuccessValue),
+                () -> assertThat(result.maybeValue().isPresent()).isEqualTo(expectedSuccessValue),
+                () -> assertThat(result.error()).isNull()
+        );
+    }
+
+    @Nested
+    class ValueOrThrow {
+
+        @Test
+        void shouldReturnValue_WhenIsNotNull() {
+            var result = new AttributeLookupResult(AttributeLookupStatus.EXISTS, "42", null);
+
+            assertThat(result.valueOrThrow()).isEqualTo("42");
+        }
+
+        @Test
+        void shouldThrowIllegalStateException_WhenValueIsNull() {
+            var result = new AttributeLookupResult(AttributeLookupStatus.DOES_NOT_EXIST, null, null);
+
+            assertThatIllegalStateException()
+                    .isThrownBy(result::valueOrThrow)
+                    .withMessage("expected value not to be null");
+        }
+    }
+}

--- a/src/test/java/org/kiwiproject/beta/base/jar/AttributesLookupResultTest.java
+++ b/src/test/java/org/kiwiproject/beta/base/jar/AttributesLookupResultTest.java
@@ -1,0 +1,76 @@
+package org.kiwiproject.beta.base.jar;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.Map;
+
+@DisplayName("AttributesLookupResult")
+class AttributesLookupResultTest {
+
+    @ParameterizedTest
+    @EnumSource(value = AttributesLookupStatus.class, names = "SUCCESS", mode = EnumSource.Mode.EXCLUDE)
+    void shouldRequireNullValue_WhenLookupFails(AttributesLookupStatus lookupStatus) {
+        var attributes = Map.of(
+                "Some-Attr", "Some-Value"
+        );
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new AttributesLookupResult(lookupStatus, attributes, null))
+                .withMessage("attributes must be null when lookup fails");
+    }
+
+    @Test
+    void shouldHaveAttributesMap_ForSuccess() {
+        var attributes = Map.of(
+                "Attribute-1", "Value-1",
+                "Attribute-2", "Value-2"
+        );
+
+        var result = new AttributesLookupResult(AttributesLookupStatus.SUCCESS, attributes, null);
+
+        assertAll(
+                () -> assertThat(result.succeeded()).isTrue(),
+                () -> assertThat(result.failed()).isFalse(),
+                () -> assertThat(result.hasAttributes()).isTrue(),
+                () -> assertThat(result.attributes()).isEqualTo(attributes),
+                () -> assertThat(result.maybeAttributes()).contains(attributes),
+                () -> assertThat(result.error()).isNull()
+        );
+    }
+
+    @Test
+    void shouldNotHaveAttributesMap_ForFailure() {
+        var result = new AttributesLookupResult(AttributesLookupStatus.FAILURE, null, null);
+
+        assertAll(
+                () -> assertThat(result.succeeded()).isFalse(),
+                () -> assertThat(result.failed()).isTrue(),
+                () -> assertThat(result.hasAttributes()).isFalse(),
+                () -> assertThat(result.attributes()).isNull(),
+                () -> assertThat(result.maybeAttributes()).isEmpty(),
+                () -> assertThat(result.error()).isNull()
+        );
+    }
+
+    @Test
+    void canHaveError_ForFailure() {
+        var error = new RuntimeException("some error");
+        var result = new AttributesLookupResult(AttributesLookupStatus.FAILURE, null, error);
+
+        assertAll(
+                () -> assertThat(result.succeeded()).isFalse(),
+                () -> assertThat(result.failed()).isTrue(),
+                () -> assertThat(result.hasAttributes()).isFalse(),
+                () -> assertThat(result.attributes()).isNull(),
+                () -> assertThat(result.maybeAttributes()).isEmpty(),
+                () -> assertThat(result.error()).isSameAs(error)
+        );
+    }
+}

--- a/src/test/java/org/kiwiproject/beta/base/jar/JarManifestHelperTest.java
+++ b/src/test/java/org/kiwiproject/beta/base/jar/JarManifestHelperTest.java
@@ -1,0 +1,248 @@
+package org.kiwiproject.beta.base.jar;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+
+@DisplayName("JarManifestHelper")
+class JarManifestHelperTest {
+
+    private JarManifestHelper helper;
+
+    @BeforeEach
+    void setUp() {
+        helper = new JarManifestHelper();
+    }
+
+    @Nested
+    class GetMainAttributeValueFromClass {
+
+        @Test
+        void shouldReturnValue_WhenAttributeExists() {
+            var lookupResult = helper.getMainAttributeValue(Test.class, "Implementation-Title");
+
+            assertAll(
+                    () -> assertThat(lookupResult.lookupStatus()).isEqualTo(AttributeLookupStatus.EXISTS),
+                    () -> assertThat(lookupResult.value()).isEqualTo("junit-jupiter-api"),
+                    () -> assertThat(lookupResult.error()).isNull()
+            );
+        }
+
+        @Test
+        void shouldReturnNull_WhenAttributeDoesNotExist() {
+            var lookupResult = helper.getMainAttributeValue(Test.class, "Bogus-Attribute");
+
+            assertAll(
+                    () -> assertThat(lookupResult.lookupStatus()).isEqualTo(AttributeLookupStatus.DOES_NOT_EXIST),
+                    () -> assertThat(lookupResult.value()).isNull(),
+                    () -> assertThat(lookupResult.error()).isNull()
+            );
+        }
+
+        @Test
+        void shouldReturnNull_WhenFailure() {
+            var lookupResult = helper.getMainAttributeValue(String.class, "Implementation-Title");
+
+            assertAll(
+                    () -> assertThat(lookupResult.lookupStatus()).isEqualTo(AttributeLookupStatus.FAILURE),
+                    () -> assertThat(lookupResult.value()).isNull(),
+                    () -> assertThat(lookupResult.error()).isInstanceOf(IllegalStateException.class)
+            );
+        }
+    }
+
+    @Nested
+    class GetMainAttributeValueFromManifest {
+
+        private Manifest manifest;
+        private Attributes mainAttributes;
+
+        @BeforeEach
+        void setUp() {
+            mainAttributes = new Attributes();
+
+            manifest = mock(Manifest.class);
+            when(manifest.getMainAttributes()).thenReturn(mainAttributes);
+        }
+
+        @Test
+        void shouldGetAttributeThatExists() {
+            var name = "Some-Attribute";
+            var value = "the.value";
+            mainAttributes.putValue(name, value);
+
+            var lookupResult = helper.getMainAttributeValue(manifest, name);
+
+            assertAll(
+                    () -> assertThat(lookupResult.lookupStatus()).isEqualTo(AttributeLookupStatus.EXISTS),
+                    () -> assertThat(lookupResult.value()).isEqualTo(value));
+        }
+
+        @Test
+        void shouldGetAttributeThatDoesNotExist() {
+            var lookupResult = helper.getMainAttributeValue(manifest, "Some-Attribute");
+
+            assertAll(
+                    () -> assertThat(lookupResult.lookupStatus()).isEqualTo(AttributeLookupStatus.DOES_NOT_EXIST),
+                    () -> assertThat(lookupResult.value()).isNull());
+        }
+    }
+
+    @Nested
+    class GetMainAttributesFromClass {
+
+        @Test
+        void shouldReturnValues_WhenAbleToReadManifest() {
+            var lookupResult = helper.getMainAttributes(Test.class);
+
+            assertAll(
+                    () -> assertThat(lookupResult.lookupStatus()).isEqualTo(AttributesLookupStatus.SUCCESS),
+                    () -> assertThat(lookupResult.attributes()).isNotEmpty(),
+                    () -> assertThat(lookupResult.error()).isNull()
+            );
+        }
+
+        @Test
+        void shouldReturnNullMap_WhenUnableToReadManifest() {
+            var lookupResult = helper.getMainAttributes(String.class);
+
+            assertAll(
+                    () -> assertThat(lookupResult.lookupStatus()).isEqualTo(AttributesLookupStatus.FAILURE),
+                    () -> assertThat(lookupResult.attributes()).isNull(),
+                    () -> assertThat(lookupResult.error()).isNull()
+            );
+        }
+    }
+
+    @Nested
+    class GetMainAttributesFromManifest {
+
+        private Manifest manifest;
+        private Attributes mainAttributes;
+
+        @BeforeEach
+        void setUp() {
+            mainAttributes = new Attributes();
+
+            manifest = mock(Manifest.class);
+            when(manifest.getMainAttributes()).thenReturn(mainAttributes);
+        }
+
+        @Test
+        void shouldGetMainAttributesAsMap() {
+            mainAttributes.put(new Attributes.Name("Attribute-1"), "value-1");
+            mainAttributes.put(new Attributes.Name("Attribute-2"), "value-2");
+            mainAttributes.put(new Attributes.Name("Attribute-3"), "value-3");
+
+            var mainAttributesMap = helper.getMainAttributes(manifest);
+            assertThat(mainAttributesMap).containsExactlyInAnyOrderEntriesOf(Map.of(
+                    "Attribute-1", "value-1",
+                    "Attribute-2", "value-2",
+                    "Attribute-3", "value-3"
+            ));
+        }
+
+        @Test
+        void shouldGetMainAttributesAsMap_WhenNoneExist() {
+            var mainAttributesMap = helper.getMainAttributes(manifest);
+            assertThat(mainAttributesMap).isEmpty();
+        }
+    }
+
+    @Nested
+    class GetManifestFromClass {
+
+        @Test
+        void shouldGetManifest() {
+            var manifestOptional = helper.getManifest(Test.class);
+            assertThat(manifestOptional).isPresent();
+        }
+
+        @Test
+        void shouldReturnEmptyOptional_WhenCannotFindIt() {
+            var manifestOptional = helper.getManifest(String.class);
+            assertThat(manifestOptional).isEmpty();
+        }
+    }
+
+    @Nested
+    class GetManifestWithResultFromClass {
+
+        @Test
+        void shouldGetManifest() {
+            var lookupResult = helper.getManifestWithResult(Test.class);
+
+            assertAll(
+                    () -> assertThat(lookupResult.succeeded()).isTrue(),
+                    () -> assertThat(lookupResult.manifest()).isNotNull()
+            );
+        }
+
+        @Test
+        void shouldReturnEmptyOptional_WhenCannotFindIt() {
+            var lookupResult = helper.getManifestWithResult(String.class);
+
+            assertAll(
+                    () -> assertThat(lookupResult.succeeded()).isFalse(),
+                    () -> assertThat(lookupResult.manifest()).isNull()
+            );
+        }
+    }
+
+    @Nested
+    class GetManifestFromURI {
+
+        @Test
+        void shouldGetManifest() throws URISyntaxException {
+            var location = Test.class.getProtectionDomain().getCodeSource().getLocation().toURI();
+            var manifestOptional = helper.getManifest(location);
+            assertThat(manifestOptional).isPresent();
+        }
+
+        @Test
+        void shouldReturnEmptyOptional_WhenCannotGetIt() {
+            var bogusURI = URI.create("file:///tmp/foo.jar");
+            var manifestOptional = helper.getManifest(bogusURI);
+            assertThat(manifestOptional).isEmpty();
+        }
+    }
+
+    @Nested
+    class GetManifestWithResultFromURI {
+
+        @Test
+        void shouldGetManifest() throws URISyntaxException {
+            var location = Test.class.getProtectionDomain().getCodeSource().getLocation().toURI();
+            var lookupResult = helper.getManifestWithResult(location);
+
+            assertAll(
+                    () -> assertThat(lookupResult.succeeded()).isTrue(),
+                    () -> assertThat(lookupResult.manifest()).isNotNull()
+            );
+        }
+
+        @Test
+        void shouldReturnEmptyOptional_WhenCannotFindIt() {
+            var location = URI.create("file:///tmp/foo.jar");
+            var lookupResult = helper.getManifestWithResult(location);
+
+            assertAll(
+                    () -> assertThat(lookupResult.succeeded()).isFalse(),
+                    () -> assertThat(lookupResult.manifest()).isNull()
+            );
+        }
+    }
+
+}

--- a/src/test/java/org/kiwiproject/beta/base/jar/ManifestLookupResultTest.java
+++ b/src/test/java/org/kiwiproject/beta/base/jar/ManifestLookupResultTest.java
@@ -1,0 +1,104 @@
+package org.kiwiproject.beta.base.jar;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.jar.Manifest;
+
+@DisplayName("ManifestLookupResult")
+class ManifestLookupResultTest {
+
+    private Manifest manifest;
+
+    @BeforeEach
+    void setUp() {
+        manifest = new Manifest();
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ManifestLookupStatus.class, names = "SUCCESS", mode = EnumSource.Mode.EXCLUDE)
+    void shouldRequireNullValue_WhenLookupFails(ManifestLookupStatus lookupStatus) {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new ManifestLookupResult(lookupStatus, manifest, null, null))
+                .withMessage("manifest must be null when lookup fails");
+    }
+
+    @Test
+    void shouldRequireNullErrorAndErrorMessage_WhenLookupSucceeds() {
+        assertAll(
+                () -> assertThatIllegalArgumentException().isThrownBy(() ->
+                        new ManifestLookupResult(ManifestLookupStatus.SUCCESS, manifest, new RuntimeException(), null)),
+
+                () -> assertThatIllegalArgumentException().isThrownBy(() ->
+                        new ManifestLookupResult(ManifestLookupStatus.SUCCESS, manifest, null, "an error"))
+        );
+    }
+
+    @Test
+    void shouldHaveManifest_WhenLookupSucceeds() {
+        var lookupResult = new ManifestLookupResult(ManifestLookupStatus.SUCCESS, manifest, null, null);
+
+        assertAll(
+                () -> assertThat(lookupResult.succeeded()).isTrue(),
+                () -> assertThat(lookupResult.failed()).isFalse(),
+                () -> assertThat(lookupResult.manifest()).isSameAs(manifest),
+                () -> assertThat(lookupResult.maybeManifest()).containsSame(manifest),
+                () -> assertThat(lookupResult.error()).isNull(),
+                () -> assertThat(lookupResult.errorMessage()).isNull()
+        );
+    }
+
+    @Test
+    void shouldNotHaveManifest_WhenLookupFails() {
+        var lookupResult = new ManifestLookupResult(ManifestLookupStatus.FAILURE, null, null, null);
+
+        assertAll(
+                () -> assertThat(lookupResult.succeeded()).isFalse(),
+                () -> assertThat(lookupResult.failed()).isTrue(),
+                () -> assertThat(lookupResult.manifest()).isNull(),
+                () -> assertThat(lookupResult.maybeManifest()).isEmpty(),
+                () -> assertThat(lookupResult.error()).isNull(),
+                () -> assertThat(lookupResult.errorMessage()).isNull()
+        );
+    }
+
+    @Test
+    void canHaveError_WhenLookupFails() {
+        var error = new SecurityException("Access Denied!");
+
+        var lookupResult = new ManifestLookupResult(ManifestLookupStatus.FAILURE, null, error, null);
+
+        assertAll(
+                () -> assertThat(lookupResult.succeeded()).isFalse(),
+                () -> assertThat(lookupResult.failed()).isTrue(),
+                () -> assertThat(lookupResult.manifest()).isNull(),
+                () -> assertThat(lookupResult.maybeManifest()).isEmpty(),
+                () -> assertThat(lookupResult.error()).isSameAs(error),
+                () -> assertThat(lookupResult.errorMessage()).isNull()
+        );
+    }
+
+    @Test
+    void canHaveErrorMessage_WhenLookupFails() {
+        var error = new SecurityException("Access Denied!");
+        var errorMessage = "some error";
+
+        var lookupResult = new ManifestLookupResult(ManifestLookupStatus.FAILURE, null, error, errorMessage);
+
+        assertAll(
+                () -> assertThat(lookupResult.succeeded()).isFalse(),
+                () -> assertThat(lookupResult.failed()).isTrue(),
+                () -> assertThat(lookupResult.manifest()).isNull(),
+                () -> assertThat(lookupResult.maybeManifest()).isEmpty(),
+                () -> assertThat(lookupResult.error()).isSameAs(error),
+                () -> assertThat(lookupResult.errorMessage()).isEqualTo(errorMessage)
+        );
+    }
+}


### PR DESCRIPTION
* Add JarManifestHelper, which is an instance-based class that contains much the same functionality as JarManifests. But instead of having only static methods, it only contains instance methods which make this much easier to mock in unit tests of classes that need to perform JAR manifest lookups.
* The methods in JarManifestHelper also return records containing more information about the lookup result, instead of returning Optional or throwing an exception. This allows callers to inspect the result and decide what action to take based on more detailed information.
* Add Javadocs to JarManifests.