### PR TITLE
Remove legacy kotlin-stdlib-common dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,12 +223,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-common</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.kiwiproject</groupId>
             <artifactId>metrics-healthchecks-severity</artifactId>
             <version>${metrics-healthchecks-severity.version}</version>


### PR DESCRIPTION
It was deprecated and removed in 2.1.0. From Kotlin 2.1 compatability guide:

The kotlin-stdlib-common.jar artifact, previously used for legacy multiplatform declarations metadata, is deprecated and replaced by .klib files as the standard format for common multiplatform declarations metadata. This change does not affect the main kotlin-stdlib.jar or kotlin-stdlib-all.jar artifacts.

reference:
https://kotlinlang.org/docs/compatibility-guide-21.html#remove-kotlin-stdlib-common-jar-artifact