### PR TITLE
Remove unnecessary null check in TypeInfo#ofParameterizedType

### DIFF
--- a/src/main/java/org/kiwiproject/beta/reflect/TypeInfo.java
+++ b/src/main/java/org/kiwiproject/beta/reflect/TypeInfo.java
@@ -2,7 +2,6 @@ package org.kiwiproject.beta.reflect;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-import static java.util.Objects.isNull;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
 import static org.kiwiproject.collect.KiwiLists.first;
@@ -95,7 +94,7 @@ public class TypeInfo {
         checkTypeArgument(parameterizedType);
 
         var typeArgs = parameterizedType.getActualTypeArguments();
-        List<Type> genericTypes = isNull(typeArgs) ? List.of() : List.of(typeArgs);
+        List<Type> genericTypes = List.of(typeArgs);
 
         return new TypeInfo(parameterizedType.getRawType(), genericTypes);
     }

--- a/src/test/java/org/kiwiproject/beta/reflect/TypeInfoTest.java
+++ b/src/test/java/org/kiwiproject/beta/reflect/TypeInfoTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.junitpioneer.jupiter.cartesian.CartesianTest;
 
@@ -107,16 +106,11 @@ class TypeInfoTest {
                     .isThrownBy(() -> TypeInfo.ofParameterizedType(null));
         }
 
-        /**
-         * We should never see a null returned from {@link ParameterizedType#getActualTypeArguments()} but we could
-         * see an empty array. Let's ensure we handle both "just in case".
-         */
-        @ParameterizedTest
-        @NullAndEmptySource
-        void shouldHandleNullAndEmptyActualTypeArguments(Type[] actualTypeArguments) {
+        @Test
+        void shouldHandleEmptyActualTypeArguments() {
             var type = mock(ParameterizedType.class);
             when(type.getRawType()).thenReturn(List.class);
-            when(type.getActualTypeArguments()).thenReturn(actualTypeArguments);
+            when(type.getActualTypeArguments()).thenReturn(new Type[0]);
 
             var typeInfo = TypeInfo.ofParameterizedType(type);
 


### PR DESCRIPTION
ParameterizedType#getActualTypeArguments does not return null, so the null check on its return value is not needed.

Fixes #487