### PR TITLE
Replace deprecated API usage

### DIFF
--- a/src/test/java/org/kiwiproject/beta/jdbc/RuntimeSQLExceptionTest.java
+++ b/src/test/java/org/kiwiproject/beta/jdbc/RuntimeSQLExceptionTest.java
@@ -17,7 +17,8 @@ class RuntimeSQLExceptionTest {
 
         assertThat(runtimeSQLException)
                 .hasMessageContaining(sqlEx.getMessage())
-                .hasCauseReference(sqlEx);
+                .cause()
+                .isSameAs(sqlEx);
     }
 
     @Test
@@ -27,6 +28,7 @@ class RuntimeSQLExceptionTest {
 
         assertThat(runtimeSQLException)
                 .hasMessage("Wrapper")
-                .hasCauseReference(sqlEx);
+                .cause()
+                .isSameAs(sqlEx);
     }
 }

--- a/src/test/java/org/kiwiproject/beta/slf4j/TimestampingLoggerTest.java
+++ b/src/test/java/org/kiwiproject/beta/slf4j/TimestampingLoggerTest.java
@@ -344,7 +344,7 @@ class TimestampingLoggerTest {
                             var nanoDuration = Duration.ofNanos(diffInNanos);
                             return new Object[] {
                                     logCount,
-                                    KiwiDurationFormatters.formatDurationWords(nanoDuration),
+                                    KiwiDurationFormatters.formatJavaDurationWords(nanoDuration),
                                     diffInNanos,
                                     nanoDuration.toMillis(),
                                     nanoDuration.toSeconds()};
@@ -455,7 +455,7 @@ class TimestampingLoggerTest {
                             var nanoDuration = Duration.ofNanos(diffInNanos);
                             return new Object[] {
                                     logCount,
-                                    KiwiDurationFormatters.formatDurationWords(nanoDuration),
+                                    KiwiDurationFormatters.formatJavaDurationWords(nanoDuration),
                                     diffInNanos,
                                     nanoDuration.toMillis(),
                                     nanoDuration.toSeconds()};


### PR DESCRIPTION
* Replace calls to deprecated KiwiDurationFormatters#formatDurationWords with KiwiDurationFormatters#formatJavaDurationWords(nanoDuration) in TimestampingLoggerTest
* Replace deprecated hasCauseReference with .cause().isSameAs(...) in RuntimeSQLExceptionTest

Fixes #489
Fixes #490
Fixes #491
Fixes #492