### PR TITLE
KiwiSlf4J enhancements to accept level names and convert String to Level

### DIFF
--- a/src/main/java/org/kiwiproject/beta/slf4j/KiwiSlf4j.java
+++ b/src/main/java/org/kiwiproject/beta/slf4j/KiwiSlf4j.java
@@ -1,9 +1,13 @@
 package org.kiwiproject.beta.slf4j;
 
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotBlank;
+
 import com.google.common.annotations.Beta;
 import lombok.experimental.UtilityClass;
 import org.slf4j.Logger;
 import org.slf4j.event.Level;
+
+import java.util.Locale;
 
 /**
  * Utilities for SLF4J, mainly to allow logging a message at a specified level. Sometimes it is useful to be able
@@ -16,6 +20,10 @@ import org.slf4j.event.Level;
 @Beta
 public class KiwiSlf4j {
 
+    public static boolean isEnabled(Logger logger, String levelName) {
+        return isEnabled(logger, levelFromStringIgnoreCase(levelName));
+    }
+
     public static boolean isEnabled(Logger logger, Level level) {
         return switch (level) {
             case ERROR -> logger.isErrorEnabled();
@@ -26,6 +34,10 @@ public class KiwiSlf4j {
         };
     }
 
+    public static void log(Logger logger, String levelName, String message) {
+        log(logger, levelFromStringIgnoreCase(levelName), message);
+    }
+
     public static void log(Logger logger, Level level, String message) {
         switch (level) {
             case ERROR -> logger.error(message);
@@ -34,6 +46,10 @@ public class KiwiSlf4j {
             case DEBUG -> logger.debug(message);
             case TRACE -> logger.trace(message);
         }
+    }
+
+    public static void log(Logger logger, String levelName, String format, Object arg) {
+        log(logger, levelFromStringIgnoreCase(levelName), format, arg);
     }
 
     @SuppressWarnings("DuplicatedCode")
@@ -47,6 +63,10 @@ public class KiwiSlf4j {
         }
     }
 
+    public static void log(Logger logger, String levelName, String format, Object arg1, Object arg2) {
+        log(logger, levelFromStringIgnoreCase(levelName), format, arg1, arg2);
+    }
+
     public static void log(Logger logger, Level level, String format, Object arg1, Object arg2) {
         switch (level) {
             case ERROR -> logger.error(format, arg1, arg2);
@@ -55,6 +75,10 @@ public class KiwiSlf4j {
             case DEBUG -> logger.debug(format, arg1, arg2);
             case TRACE -> logger.trace(format, arg1, arg2);
         }
+    }
+
+    public static void log(Logger logger, String levelName, String format, Object... arguments) {
+        log(logger, levelFromStringIgnoreCase(levelName), format, arguments);
     }
 
     @SuppressWarnings("DuplicatedCode")
@@ -66,7 +90,10 @@ public class KiwiSlf4j {
             case DEBUG -> logger.debug(format, arguments);
             case TRACE -> logger.trace(format, arguments);
         }
+    }
 
+    public static void log(Logger logger, String levelName, String message, Throwable t) {
+        log(logger, levelFromStringIgnoreCase(levelName), message, t);
     }
 
     @SuppressWarnings("DuplicatedCode")
@@ -78,5 +105,20 @@ public class KiwiSlf4j {
             case DEBUG -> logger.debug(message, t);
             case TRACE -> logger.trace(message, t);
         }
+    }
+
+    /**
+     * Matches the given {@code levelNameString} to a value in {@link Level},
+     * independent of the character case (lower or upper).
+     * <p>
+     * For example, the strings "WARN", "warn", and "Warn" all match {@link Level#WARN}.
+     * 
+     * @param levelNameString a String whose uppercased value maps to one of the values in {@code Level}
+     * @return the matching SLF4J {@code Level}
+     * @throws IllegalArgumentException if there is no matching {@code Level}
+     */
+    public static Level levelFromStringIgnoreCase(String levelNameString) {
+        checkArgumentNotBlank(levelNameString, "levelNameString must not be blank");
+        return Level.valueOf(levelNameString.toUpperCase(Locale.ENGLISH));
     }
 }

--- a/src/main/java/org/kiwiproject/beta/slf4j/KiwiSlf4j.java
+++ b/src/main/java/org/kiwiproject/beta/slf4j/KiwiSlf4j.java
@@ -115,7 +115,7 @@ public class KiwiSlf4j {
      * 
      * @param levelNameString a String whose uppercased value maps to one of the values in {@code Level}
      * @return the matching SLF4J {@code Level}
-     * @throws IllegalArgumentException if there is no matching {@code Level}
+     * @throws IllegalArgumentException if {@code levelNameString} is blank or there is no matching {@code Level}
      */
     public static Level toLevelIgnoreCase(String levelNameString) {
         checkArgumentNotBlank(levelNameString, "levelNameString must not be blank");

--- a/src/main/java/org/kiwiproject/beta/slf4j/KiwiSlf4j.java
+++ b/src/main/java/org/kiwiproject/beta/slf4j/KiwiSlf4j.java
@@ -21,7 +21,7 @@ import java.util.Locale;
 public class KiwiSlf4j {
 
     public static boolean isEnabled(Logger logger, String levelName) {
-        return isEnabled(logger, levelFromStringIgnoreCase(levelName));
+        return isEnabled(logger, toLevelIgnoreCase(levelName));
     }
 
     public static boolean isEnabled(Logger logger, Level level) {
@@ -35,7 +35,7 @@ public class KiwiSlf4j {
     }
 
     public static void log(Logger logger, String levelName, String message) {
-        log(logger, levelFromStringIgnoreCase(levelName), message);
+        log(logger, toLevelIgnoreCase(levelName), message);
     }
 
     public static void log(Logger logger, Level level, String message) {
@@ -49,7 +49,7 @@ public class KiwiSlf4j {
     }
 
     public static void log(Logger logger, String levelName, String format, Object arg) {
-        log(logger, levelFromStringIgnoreCase(levelName), format, arg);
+        log(logger, toLevelIgnoreCase(levelName), format, arg);
     }
 
     @SuppressWarnings("DuplicatedCode")
@@ -64,7 +64,7 @@ public class KiwiSlf4j {
     }
 
     public static void log(Logger logger, String levelName, String format, Object arg1, Object arg2) {
-        log(logger, levelFromStringIgnoreCase(levelName), format, arg1, arg2);
+        log(logger, toLevelIgnoreCase(levelName), format, arg1, arg2);
     }
 
     public static void log(Logger logger, Level level, String format, Object arg1, Object arg2) {
@@ -78,7 +78,7 @@ public class KiwiSlf4j {
     }
 
     public static void log(Logger logger, String levelName, String format, Object... arguments) {
-        log(logger, levelFromStringIgnoreCase(levelName), format, arguments);
+        log(logger, toLevelIgnoreCase(levelName), format, arguments);
     }
 
     @SuppressWarnings("DuplicatedCode")
@@ -93,7 +93,7 @@ public class KiwiSlf4j {
     }
 
     public static void log(Logger logger, String levelName, String message, Throwable t) {
-        log(logger, levelFromStringIgnoreCase(levelName), message, t);
+        log(logger, toLevelIgnoreCase(levelName), message, t);
     }
 
     @SuppressWarnings("DuplicatedCode")
@@ -117,7 +117,7 @@ public class KiwiSlf4j {
      * @return the matching SLF4J {@code Level}
      * @throws IllegalArgumentException if there is no matching {@code Level}
      */
-    public static Level levelFromStringIgnoreCase(String levelNameString) {
+    public static Level toLevelIgnoreCase(String levelNameString) {
         checkArgumentNotBlank(levelNameString, "levelNameString must not be blank");
         return Level.valueOf(levelNameString.toUpperCase(Locale.ENGLISH));
     }

--- a/src/test/java/org/kiwiproject/beta/slf4j/KiwiSlf4jTest.java
+++ b/src/test/java/org/kiwiproject/beta/slf4j/KiwiSlf4jTest.java
@@ -247,9 +247,9 @@ class KiwiSlf4jTest {
 
     @ParameterizedTest
     @MinimalBlankStringSource
-    void shouldRequireLevelName_WhenGettingLevel(String value) {
+    void toLevelIgnoreCase_shouldRequireLevelName(String value) {
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> KiwiSlf4j.levelFromStringIgnoreCase(value))
+                .isThrownBy(() -> KiwiSlf4j.toLevelIgnoreCase(value))
                 .withMessage("levelNameString must not be blank");
     }
 
@@ -263,9 +263,9 @@ class KiwiSlf4jTest {
         "_warn_",
         "FATAL"
     })
-    void shouldThrowIllegalArgumentException_WhenGettingLevel_ButNoneMatch(String value) {
+    void toLevelIgnoreCase_shouldThrowIllegalArgumentException_WhenNoneMatch(String value) {
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> KiwiSlf4j.levelFromStringIgnoreCase(value))
+                .isThrownBy(() -> KiwiSlf4j.toLevelIgnoreCase(value))
                 .withMessage("No enum constant org.slf4j.event.Level." + value.toUpperCase(Locale.ENGLISH));
     }
 
@@ -292,8 +292,8 @@ class KiwiSlf4jTest {
             Error, ERROR
             ERRoR, ERROR
             """)
-    void shouldGetLevelFromString_IgnoringCase(String levelName, Level expectedLevel) {
-        var level = KiwiSlf4j.levelFromStringIgnoreCase(levelName);
+    void toLevelIgnoreCase_shouldGetLevel_IgnoringCase(String levelName, Level expectedLevel) {
+        var level = KiwiSlf4j.toLevelIgnoreCase(levelName);
         assertThat(level).isSameAs(expectedLevel);
     }
 }


### PR DESCRIPTION
* Add toLevelIgnoreCase method to get the Level object that matches a string whose characters have all been converted to uppercase.
* Add overloads for the isEnabled and log methods that accept a String for the level name instead of the Level object. The level name is case-insensitive, so that "warn", "Warn", "WARN", and even "WaRn" all match Level.WARN.
* For the tests, I chose to copy and modify the existing implementations instead of changing the tests to always call the methods that accept a String (since they convert the level name to Level and then delegate to the ones that accept Level). I made this choice to keep the tests completely independent, at the cost of some duplicate test code.