### PR TITLE
Add KiwiCasts2

### DIFF
--- a/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
+++ b/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
@@ -82,7 +82,7 @@ public class KiwiCasts2 {
         }
     }
 
-    record ElementCheckResult(boolean ok, Object invalidValue) {
+    private record ElementCheckResult(boolean ok, Object invalidValue) {
         static ElementCheckResult okCollection() {
             return new ElementCheckResult(true, null);
         }
@@ -375,6 +375,7 @@ public class KiwiCasts2 {
             KEY, VALUE
         }
 
+        @VisibleForTesting
         record EntryCheckResult(boolean ok, EntryType entryType, Object invalidValue) {
             static EntryCheckResult okMap() {
                 return new EntryCheckResult(true, null, null);

--- a/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
+++ b/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
@@ -203,7 +203,7 @@ public class KiwiCasts2 {
     public static <T> Collection<T> castToCollectionAndCheckElements(Class<T> expectedType,
                                                                      Object object,
                                                                      CollectionCheckStrategy strategy) {
-        checkArgumentNotNull(object, "object must not be null");
+        checkObjectNotNull(object);
         checkExpectedTypeNotNull(expectedType);
         try {
             Collection<T> coll = uncheckedCast(object);
@@ -334,7 +334,7 @@ public class KiwiCasts2 {
     public static <T> List<T> castToListAndCheckElements(Class<T> expectedType,
                                                          Object object,
                                                          ListCheckStrategy strategy) {
-        checkArgumentNotNull(object, "object must not be null");
+        checkObjectNotNull(object);
         checkExpectedTypeNotNull(expectedType);
         try {
             List<T> list = uncheckedCast(object);
@@ -504,7 +504,7 @@ public class KiwiCasts2 {
     public static <T> Set<T> castToSetAndCheckElements(Class<T> expectedType,
                                                        Object object,
                                                        SetCheckStrategy strategy) {
-        checkArgumentNotNull(object, "object must not be null");
+        checkObjectNotNull(object);
         checkExpectedTypeNotNull(expectedType);
         try {
             Set<T> set = uncheckedCast(object);
@@ -724,7 +724,7 @@ public class KiwiCasts2 {
                                                             Object object,
                                                             MapCheckStrategy strategy) {
 
-        checkArgumentNotNull(object, "object must not be null");
+        checkObjectNotNull(object);
         checkArgumentNotNull(keyType, "keyType must not be null");
         checkArgumentNotNull(valueType, "valueType must not be null");
         try {
@@ -749,5 +749,9 @@ public class KiwiCasts2 {
             ClassCastException e) {
 
         return TypeMismatchException.forUnexpectedTypeWithCause(expectedType, object.getClass(), e);
+    }
+
+    private static void checkObjectNotNull(Object object) {
+        checkArgumentNotNull(object, "object must not be null");
     }
 }

--- a/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
+++ b/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
@@ -744,10 +744,6 @@ public class KiwiCasts2 {
             Object object,
             ClassCastException e) {
 
-        if (isNull(object)) {
-            return TypeMismatchException.forExpectedTypeWithCause(expectedType, e);
-        }
-
         return TypeMismatchException.forUnexpectedTypeWithCause(expectedType, object.getClass(), e);
     }
 }

--- a/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
+++ b/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
@@ -229,15 +229,16 @@ public class KiwiCasts2 {
     }
 
     /**
-     * Default implementation of {@link ListCheckStrategy} that uses a standard strategy
-     * with default non-null checks and a single type check.
+     * Default implementation of {@link ListCheckStrategy} that uses
+     * {@link #DEFAULT_MAX_NON_NULL_CHECKS} as the maximum non-null checks
+     * and checks only one (non-null) element in the collection.
      */
     public static class DefaultListCheckStrategy implements ListCheckStrategy {
 
         private final StandardListCheckStrategy strategy;
 
         /**
-         * Constructs a new instance with default settings.
+         * Constructs a new instance.
          */
         public DefaultListCheckStrategy() {
             strategy = StandardListCheckStrategy.of(DEFAULT_MAX_NON_NULL_CHECKS, 1);
@@ -268,8 +269,11 @@ public class KiwiCasts2 {
 
         /**
          * Creates a new instance with default settings for maximum non-null and type checks.
+         * <p>
+         * Uses {@link #DEFAULT_MAX_NON_NULL_CHECKS} and {@link #DEFAULT_MAX_TYPE_CHECKS} as the
+         * values for {@code maxNonNullChecks} and {@code maxElementTypeChecks}, respectively.
          *
-         * @return a new instance with default settings
+         * @return a new instance
          */
         public static StandardListCheckStrategy ofDefaults() {
             return new StandardListCheckStrategy(DEFAULT_MAX_NON_NULL_CHECKS, DEFAULT_MAX_TYPE_CHECKS);
@@ -303,7 +307,7 @@ public class KiwiCasts2 {
 
     /**
      * Casts the given object to a List and checks that its elements are of the expected type.
-     * Uses the default list check strategy.
+     * Uses {@link DefaultListCheckStrategy} as the list check strategy.
      *
      * @param expectedType the expected type of elements in the list
      * @param object the object to cast to a List

--- a/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
+++ b/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
@@ -414,7 +414,7 @@ public class KiwiCasts2 {
                 Class<?> expectedValueType,
                 Map<K, V> map,
                 int maxNonNullChecks,
-                int maxElementTypeChecks) {
+                int maxEntryTypeChecks) {
 
             if (KiwiMaps.isNullOrEmpty(map)) {
                 // We can't verify type information about a null or empty map
@@ -450,7 +450,7 @@ public class KiwiCasts2 {
 
                 if (!keyIsNull || !valueIsNull) {
                     typeCheckCount++;
-                    if (typeCheckCount >= maxElementTypeChecks) {
+                    if (typeCheckCount >= maxEntryTypeChecks) {
                         break;
                     }
                 }

--- a/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
+++ b/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
@@ -32,8 +32,15 @@ import java.util.Set;
 @UtilityClass
 public class KiwiCasts2 {
 
-    private static final int DEFAULT_MAX_NON_NULL_CHECKS = 10;
-    private static final int DEFAULT_MAX_TYPE_CHECKS = 10;
+    /**
+     * The default maximum number of non-null checks to perform when checking elements in a collection.
+     */
+    public static final int DEFAULT_MAX_NON_NULL_CHECKS = 10;
+
+    /**
+     * The default maximum number of type checks to perform when checking elements in a collection.
+     */
+    public static final int DEFAULT_MAX_TYPE_CHECKS = 10;
 
     private static final CollectionCheckStrategy DEFAULT_COLLECTION_CHECK_STRATEGY =
             new DefaultCollectionCheckStrategy();
@@ -81,15 +88,16 @@ public class KiwiCasts2 {
     }
 
     /**
-     * Default implementation of {@link CollectionCheckStrategy} that uses a standard strategy
-     * with default non-null checks and a single type check.
+     * Default implementation of {@link CollectionCheckStrategy} that uses
+     * {@link #DEFAULT_MAX_NON_NULL_CHECKS} as the maximum non-null checks
+     * and checks only one (non-null) element in the collection.
      */
     public static class DefaultCollectionCheckStrategy implements CollectionCheckStrategy {
 
         private final StandardCollectionCheckStrategy strategy;
 
         /**
-         * Constructs a new instance with default settings.
+         * Constructs a new instance.
          */
         public DefaultCollectionCheckStrategy() {
             strategy = StandardCollectionCheckStrategy.of(DEFAULT_MAX_NON_NULL_CHECKS, 1);
@@ -131,8 +139,11 @@ public class KiwiCasts2 {
 
         /**
          * Creates a new instance with default settings for maximum non-null and type checks.
+         * <p>
+         * Uses {@link #DEFAULT_MAX_NON_NULL_CHECKS} and {@link #DEFAULT_MAX_TYPE_CHECKS} as the
+         * values for {@code maxNonNullChecks} and {@code maxElementTypeChecks}, respectively.
          *
-         * @return a new instance with default settings
+         * @return a new instance
          */
         public static StandardCollectionCheckStrategy ofDefaults() {
             return new StandardCollectionCheckStrategy(DEFAULT_MAX_NON_NULL_CHECKS, DEFAULT_MAX_TYPE_CHECKS);
@@ -166,7 +177,7 @@ public class KiwiCasts2 {
 
     /**
      * Casts the given object to a Collection and checks that its elements are of the expected type.
-     * Uses the default collection check strategy.
+     * Uses {@link DefaultCollectionCheckStrategy} as the collection check strategy.
      *
      * @param expectedType the expected type of elements in the collection
      * @param object the object to cast to a Collection
@@ -180,7 +191,7 @@ public class KiwiCasts2 {
 
     /**
      * Casts the given object to a Collection and checks that its elements are of the expected type
-     * using the specified check strategy.
+     * using the specified strategy.
      *
      * @param expectedType the expected type of elements in the collection
      * @param object the object to cast to a Collection

--- a/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
+++ b/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
@@ -428,29 +428,23 @@ public class KiwiCasts2 {
                 K key = entry.getKey();
                 V value = entry.getValue();
 
-                var keyIsNull = isNull(key);
-                var valueIsNull = isNull(value);
+                var keyIsNotNull = nonNull(key);
+                var valueIsNotNull = nonNull(value);
 
-                if (keyIsNull || valueIsNull) {
-                    nullCheckCount++;
-                    if (nullCheckCount > maxNonNullChecks) {
-                        return EntryCheckResult.okMap();
-                    }
+                if ((isNull(key) || isNull(value)) && ++nullCheckCount > maxNonNullChecks) {
+                    return EntryCheckResult.okMap();
                 }
 
-                if (!keyIsNull && isNotExpectedType(expectedKeyType, key)) {
+                if (keyIsNotNull && isNotExpectedType(expectedKeyType, key)) {
                     return EntryCheckResult.foundInvalidType(EntryType.KEY, key);
                 }
 
-                if (!valueIsNull && isNotExpectedType(expectedValueType, value)) {
+                if (valueIsNotNull && isNotExpectedType(expectedValueType, value)) {
                     return EntryCheckResult.foundInvalidType(EntryType.VALUE, value);
                 }
 
-                if (!keyIsNull || !valueIsNull) {
-                    typeCheckCount++;
-                    if (typeCheckCount >= maxEntryTypeChecks) {
-                        break;
-                    }
+                if ((keyIsNotNull || valueIsNotNull) && ++typeCheckCount >= maxEntryTypeChecks) {
+                    break;
                 }
             }
 

--- a/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
+++ b/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
@@ -662,7 +662,7 @@ public class KiwiCasts2 {
                 var keyIsNotNull = nonNull(key);
                 var valueIsNotNull = nonNull(value);
 
-                if ((isNull(key) || isNull(value)) && ++nullCheckCount > maxNonNullChecks) {
+                if (eitherIsNull(key, value) && ++nullCheckCount > maxNonNullChecks) {
                     return EntryCheckResult.okMap();
                 }
 
@@ -680,6 +680,10 @@ public class KiwiCasts2 {
             }
 
             return EntryCheckResult.okMap();
+        }
+
+        private static boolean eitherIsNull(Object o1, Object o2) {
+            return isNull(o1) || isNull(o2);
         }
     }
 

--- a/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
+++ b/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
@@ -167,12 +167,42 @@ public class KiwiCasts2 {
 
     public static class DefaultListCheckStrategy implements ListCheckStrategy {
 
+        private final StandardListCheckStrategy strategy;
+
+        public DefaultListCheckStrategy() {
+            strategy = StandardListCheckStrategy.of(DEFAULT_MAX_NON_NULL_CHECKS, 1);
+        }
+
         @Override
         public <T> List<T> checkElements(Class<T> expectedType, List<T> list) {
-            var checkResult = checkElementsDefaultStrategy(expectedType, list);
+            return strategy.checkElements(expectedType, list);
+        }
+    }
+
+    public static class StandardListCheckStrategy implements ListCheckStrategy {
+
+        private final int maxNonNullChecks;
+        private final int maxElementTypeChecks;
+
+        private StandardListCheckStrategy(int maxNonNullChecks, int maxElementTypeChecks) {
+            this.maxNonNullChecks = maxNonNullChecks;
+            this.maxElementTypeChecks = maxElementTypeChecks;
+        }
+
+        public static StandardListCheckStrategy ofDefaults() {
+            return new StandardListCheckStrategy(DEFAULT_MAX_NON_NULL_CHECKS, DEFAULT_MAX_TYPE_CHECKS);
+        }
+
+        public static StandardListCheckStrategy of(int maxNonNullChecks, int maxElementTypeChecks) {
+            return new StandardListCheckStrategy(maxNonNullChecks, maxElementTypeChecks);
+        }
+
+        @Override
+        public <T> List<T> checkElements(Class<T> expectedType, List<T> coll) throws TypeMismatchException {
+            var checkResult = checkElementsStandardStrategy(expectedType, coll, maxNonNullChecks, maxElementTypeChecks);
 
             if (checkResult.ok()) {
-                return list;
+                return coll;
             }
 
             throw newCollectionTypeMismatch(List.class, expectedType, checkResult);

--- a/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
+++ b/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
@@ -54,6 +54,8 @@ public class KiwiCasts2 {
     private static final MapCheckStrategy DEFAULT_MAP_CHECK_STRATEGY =
             new DefaultMapCheckStrategy();
 
+    private static final String STRATEGY_MUST_NOT_BE_NULL = "strategy must not be null";
+
 
     /**
      * Performs an unchecked cast of the given object to the specified type.
@@ -205,6 +207,7 @@ public class KiwiCasts2 {
                                                                      CollectionCheckStrategy strategy) {
         checkObjectNotNull(object);
         checkExpectedTypeNotNull(expectedType);
+        checkArgumentNotNull(strategy, STRATEGY_MUST_NOT_BE_NULL);
         try {
             Collection<T> coll = uncheckedCast(object);
             return strategy.checkElements(expectedType, coll);
@@ -336,6 +339,7 @@ public class KiwiCasts2 {
                                                          ListCheckStrategy strategy) {
         checkObjectNotNull(object);
         checkExpectedTypeNotNull(expectedType);
+        checkArgumentNotNull(strategy, STRATEGY_MUST_NOT_BE_NULL);
         try {
             List<T> list = uncheckedCast(object);
             return strategy.checkElements(expectedType, list);
@@ -506,6 +510,7 @@ public class KiwiCasts2 {
                                                        SetCheckStrategy strategy) {
         checkObjectNotNull(object);
         checkExpectedTypeNotNull(expectedType);
+        checkArgumentNotNull(strategy, STRATEGY_MUST_NOT_BE_NULL);
         try {
             Set<T> set = uncheckedCast(object);
             return strategy.checkElements(expectedType, set);
@@ -690,6 +695,14 @@ public class KiwiCasts2 {
         }
     }
 
+    private static boolean isNotExpectedType(Class<?> expectedType, Object object) {
+        return !isExpectedType(expectedType, object);
+    }
+
+    private static boolean isExpectedType(Class<?> expectedType, Object object) {
+        return expectedType.isAssignableFrom(object.getClass());
+    }
+
     /**
      * Casts the given object to a Map and checks that its keys and values are of the expected types.
      * Uses {@link DefaultMapCheckStrategy} as the map check strategy.
@@ -727,6 +740,7 @@ public class KiwiCasts2 {
         checkObjectNotNull(object);
         checkArgumentNotNull(keyType, "keyType must not be null");
         checkArgumentNotNull(valueType, "valueType must not be null");
+        checkArgumentNotNull(strategy, STRATEGY_MUST_NOT_BE_NULL);
         try {
             Map<K, V> map = uncheckedCast(object);
             return strategy.checkEntries(keyType, valueType, map);
@@ -735,12 +749,8 @@ public class KiwiCasts2 {
         }
     }
 
-    private static boolean isNotExpectedType(Class<?> expectedType, Object object) {
-        return !isExpectedType(expectedType, object);
-    }
-
-    private static boolean isExpectedType(Class<?> expectedType, Object object) {
-        return expectedType.isAssignableFrom(object.getClass());
+    private static void checkObjectNotNull(Object object) {
+        checkArgumentNotNull(object, "object must not be null");
     }
 
     private static <T> TypeMismatchException typeMismatchExceptionForUnexpectedType(
@@ -749,9 +759,5 @@ public class KiwiCasts2 {
             ClassCastException e) {
 
         return TypeMismatchException.forUnexpectedTypeWithCause(expectedType, object.getClass(), e);
-    }
-
-    private static void checkObjectNotNull(Object object) {
-        checkArgumentNotNull(object, "object must not be null");
     }
 }

--- a/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
+++ b/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
@@ -316,37 +316,15 @@ public class KiwiCasts2 {
 
     public static class DefaultMapCheckStrategy implements MapCheckStrategy {
 
+        private final StandardMapCheckStrategy strategy;
+
+        public DefaultMapCheckStrategy() {
+            strategy = StandardMapCheckStrategy.of(DEFAULT_MAX_NON_NULL_CHECKS, 1);
+        }
+
         @Override
         public <K, V> Map<K, V> checkEntries(Class<K> keyType, Class<V> valueType, Map<K, V> map) {
-            if (KiwiMaps.isNullOrEmpty(map)) {
-                // We can't verify type information about a null or empty map
-                return map;
-            }
-
-            // Find first non-null key with non-null value
-            Map.Entry<K, V> firstNonNullEntry = map.entrySet().stream()
-                    .filter(entry -> nonNull(entry.getKey()) && nonNull(entry.getValue()))
-                    .limit(DEFAULT_MAX_NON_NULL_CHECKS)
-                    .findFirst()
-                    .orElse(null);
-
-            if (isNull(firstNonNullEntry)) {
-                // We didn't find an entry with a non-null key and value quickly, so give up
-                return map;
-            }
-
-            var key = firstNonNullEntry.getKey();
-
-            if (isExpectedType(keyType, key)) {
-                var theValue = map.get(key);
-                if (isExpectedType(valueType, theValue)) {
-                    return map;
-                } else {
-                    throw TypeMismatchException.forMapValueTypeMismatch(valueType, theValue.getClass());
-                }
-            }
-
-            throw TypeMismatchException.forMapKeyTypeMismatch(keyType, key.getClass());
+            return strategy.checkEntries(keyType, valueType, map);
         }
     }
 

--- a/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
+++ b/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
@@ -198,11 +198,11 @@ public class KiwiCasts2 {
         }
 
         @Override
-        public <T> List<T> checkElements(Class<T> expectedType, List<T> coll) throws TypeMismatchException {
-            var checkResult = checkElementsStandardStrategy(expectedType, coll, maxNonNullChecks, maxElementTypeChecks);
+        public <T> List<T> checkElements(Class<T> expectedType, List<T> list) throws TypeMismatchException {
+            var checkResult = checkElementsStandardStrategy(expectedType, list, maxNonNullChecks, maxElementTypeChecks);
 
             if (checkResult.ok()) {
-                return coll;
+                return list;
             }
 
             throw newCollectionTypeMismatch(List.class, expectedType, checkResult);

--- a/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
+++ b/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
@@ -208,7 +208,7 @@ public class KiwiCasts2 {
             Collection<T> coll = uncheckedCast(object);
             return strategy.checkElements(expectedType, coll);
         } catch (ClassCastException e) {
-            throw TypeMismatchException.forTypeMismatch(Collection.class, e);
+            throw TypeMismatchException.forExpectedTypeWithCause(Collection.class, e);
         }
     }
 
@@ -338,7 +338,7 @@ public class KiwiCasts2 {
             List<T> list = uncheckedCast(object);
             return strategy.checkElements(expectedType, list);
         } catch (ClassCastException e) {
-            throw TypeMismatchException.forTypeMismatch(List.class, e);
+            throw TypeMismatchException.forExpectedTypeWithCause(List.class, e);
         }
     }
 
@@ -471,7 +471,7 @@ public class KiwiCasts2 {
     }
 
     private static TypeMismatchException newCollectionTypeMismatch(Class<?> collectionType, Class<?> expectedType, ElementCheckResult checkResult) {
-        return TypeMismatchException.forCollectionTypeMismatch(collectionType, expectedType, checkResult.invalidValue().getClass());
+        return TypeMismatchException.forUnexpectedCollectionElementType(collectionType, expectedType, checkResult.invalidValue().getClass());
     }
 
     /**
@@ -507,7 +507,7 @@ public class KiwiCasts2 {
             Set<T> set = uncheckedCast(object);
             return strategy.checkElements(expectedType, set);
         } catch (ClassCastException e) {
-            throw TypeMismatchException.forTypeMismatch(Set.class, e);
+            throw TypeMismatchException.forExpectedTypeWithCause(Set.class, e);
         }
     }
 
@@ -610,11 +610,11 @@ public class KiwiCasts2 {
                     "entryType must not be null when result is not ok");
 
             if (entryType == EntryType.KEY) {
-                throw TypeMismatchException.forMapKeyTypeMismatch(keyType, checkResult.invalidValue().getClass());
+                throw TypeMismatchException.forUnexpectedMapKeyType(keyType, checkResult.invalidValue().getClass());
             }
 
             checkEntryTypeIsValue(checkResult);
-            throw TypeMismatchException.forMapValueTypeMismatch(valueType, checkResult.invalidValue().getClass());
+            throw TypeMismatchException.forUnexpectedMapValueType(valueType, checkResult.invalidValue().getClass());
         }
 
         @VisibleForTesting
@@ -727,7 +727,7 @@ public class KiwiCasts2 {
             Map<K, V> map = uncheckedCast(object);
             return strategy.checkEntries(keyType, valueType, map);
         } catch (ClassCastException e) {
-            throw TypeMismatchException.forTypeMismatch(Map.class, e);
+            throw TypeMismatchException.forExpectedTypeWithCause(Map.class, e);
         }
     }
 

--- a/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
+++ b/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
@@ -334,6 +334,7 @@ public class KiwiCasts2 {
     public static <T> List<T> castToListAndCheckElements(Class<T> expectedType,
                                                          Object object,
                                                          ListCheckStrategy strategy) {
+        checkArgumentNotNull(object, "object must not be null");
         checkExpectedTypeNotNull(expectedType);
         try {
             List<T> list = uncheckedCast(object);
@@ -503,6 +504,7 @@ public class KiwiCasts2 {
     public static <T> Set<T> castToSetAndCheckElements(Class<T> expectedType,
                                                        Object object,
                                                        SetCheckStrategy strategy) {
+        checkArgumentNotNull(object, "object must not be null");
         checkExpectedTypeNotNull(expectedType);
         try {
             Set<T> set = uncheckedCast(object);
@@ -722,6 +724,7 @@ public class KiwiCasts2 {
                                                             Object object,
                                                             MapCheckStrategy strategy) {
 
+        checkArgumentNotNull(object, "object must not be null");
         checkArgumentNotNull(keyType, "keyType must not be null");
         checkArgumentNotNull(valueType, "valueType must not be null");
         try {

--- a/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
+++ b/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
@@ -203,6 +203,7 @@ public class KiwiCasts2 {
     public static <T> Collection<T> castToCollectionAndCheckElements(Class<T> expectedType,
                                                                      Object object,
                                                                      CollectionCheckStrategy strategy) {
+        checkArgumentNotNull(object, "object must not be null");
         checkExpectedTypeNotNull(expectedType);
         try {
             Collection<T> coll = uncheckedCast(object);

--- a/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
+++ b/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
@@ -33,17 +33,18 @@ public class KiwiCasts2 {
     private static final int DEFAULT_MAX_NON_NULL_CHECKS = 10;
     private static final int DEFAULT_MAX_TYPE_CHECKS = 10;
 
-    private static final CollectionCheckStrategy DEFAULT_COLLECTION_ELEMENT_CHECKING_STRATEGY =
+    private static final CollectionCheckStrategy DEFAULT_COLLECTION_CHECK_STRATEGY =
             new DefaultCollectionCheckStrategy();
 
-    private static final DefaultListCheckStrategy DEFAULT_LIST_ELEMENT_CHECKING_STRATEGY =
+    private static final DefaultListCheckStrategy DEFAULT_LIST_CHECK_STRATEGY =
             new DefaultListCheckStrategy();
 
-    private static final MapCheckStrategy DEFAULT_MAP_ELEMENT_CHECKING_STRATEGY =
+    private static final SetCheckStrategy DEFAULT_SET_CHECK_STRATEGY =
+            new DefaultSetCheckStrategy();
+
+    private static final MapCheckStrategy DEFAULT_MAP_CHECK_STRATEGY =
             new DefaultMapCheckStrategy();
 
-    private static final SetCheckStrategy DEFAULT_SET_ELEMENT_CHECKING_STRATEGY =
-            new DefaultSetCheckStrategy();
 
     /**
      * Performs an unchecked cast of the given object to the specified type.
@@ -145,7 +146,7 @@ public class KiwiCasts2 {
     }
 
     public static <T> Collection<T> castToCollectionAndCheckElements(Class<T> expectedType, Object object) {
-        return castToCollectionAndCheckElements(expectedType, object, DEFAULT_COLLECTION_ELEMENT_CHECKING_STRATEGY);
+        return castToCollectionAndCheckElements(expectedType, object, DEFAULT_COLLECTION_CHECK_STRATEGY);
     }
 
     public static <T> Collection<T> castToCollectionAndCheckElements(Class<T> expectedType,
@@ -179,7 +180,7 @@ public class KiwiCasts2 {
     }
 
     public static <T> List<T> castToListAndCheckElements(Class<T> expectedType, Object object) {
-        return castToListAndCheckElements(expectedType, object, DEFAULT_LIST_ELEMENT_CHECKING_STRATEGY);
+        return castToListAndCheckElements(expectedType, object, DEFAULT_LIST_CHECK_STRATEGY);
     }
 
     public static <T> List<T> castToListAndCheckElements(Class<T> expectedType,
@@ -248,7 +249,7 @@ public class KiwiCasts2 {
     }
 
     public static <T> Set<T> castToSetAndCheckElements(Class<T> expectedType, Object object) {
-        return castToSetAndCheckElements(expectedType, object, DEFAULT_SET_ELEMENT_CHECKING_STRATEGY);
+        return castToSetAndCheckElements(expectedType, object, DEFAULT_SET_CHECK_STRATEGY);
     }
 
     public static <T> Set<T> castToSetAndCheckElements(Class<T> expectedType,
@@ -324,7 +325,7 @@ public class KiwiCasts2 {
     }
 
     public static <K, V> Map<K, V> castToMapAndCheckEntries(Class<K> keyType, Class<V> valueType, Object object) {
-        return castToMapAndCheckEntries(keyType, valueType, object, DEFAULT_MAP_ELEMENT_CHECKING_STRATEGY);
+        return castToMapAndCheckEntries(keyType, valueType, object, DEFAULT_MAP_CHECK_STRATEGY);
     }
 
     public static <K, V> Map<K, V> castToMapAndCheckEntries(Class<K> keyType,

--- a/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
+++ b/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
@@ -231,7 +231,7 @@ public class KiwiCasts2 {
     /**
      * Default implementation of {@link ListCheckStrategy} that uses
      * {@link #DEFAULT_MAX_NON_NULL_CHECKS} as the maximum non-null checks
-     * and checks only one (non-null) element in the collection.
+     * and checks only one (non-null) element in the list.
      */
     public static class DefaultListCheckStrategy implements ListCheckStrategy {
 
@@ -359,15 +359,16 @@ public class KiwiCasts2 {
     }
 
     /**
-     * Default implementation of {@link SetCheckStrategy} that uses a standard strategy
-     * with default non-null checks and a single type check.
+     * Default implementation of {@link SetCheckStrategy} that uses
+     * {@link #DEFAULT_MAX_NON_NULL_CHECKS} as the maximum non-null checks
+     * and checks only one (non-null) element in the set.
      */
     public static class DefaultSetCheckStrategy implements SetCheckStrategy {
 
         private final StandardSetCheckStrategy strategy;
 
         /**
-         * Constructs a new instance with default settings.
+         * Constructs a new instance.
          */
         public DefaultSetCheckStrategy() {
             strategy = StandardSetCheckStrategy.of(DEFAULT_MAX_NON_NULL_CHECKS, 1);
@@ -398,8 +399,11 @@ public class KiwiCasts2 {
 
         /**
          * Creates a new instance with default settings for maximum non-null and type checks.
+         * <p>
+         * Uses {@link #DEFAULT_MAX_NON_NULL_CHECKS} and {@link #DEFAULT_MAX_TYPE_CHECKS} as the
+         * values for {@code maxNonNullChecks} and {@code maxElementTypeChecks}, respectively.
          *
-         * @return a new instance with default settings
+         * @return a new instance
          */
         public static StandardSetCheckStrategy ofDefaults() {
             return new StandardSetCheckStrategy(DEFAULT_MAX_NON_NULL_CHECKS, DEFAULT_MAX_TYPE_CHECKS);

--- a/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
+++ b/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
@@ -430,47 +430,26 @@ public class KiwiCasts2 {
                 K key = entry.getKey();
                 V value = entry.getValue();
 
-                if (isNull(key) && nonNull(value)) {
+                var keyIsNull = isNull(key);
+                var valueIsNull = isNull(value);
+
+                if (keyIsNull || valueIsNull) {
                     nullCheckCount++;
                     if (nullCheckCount > maxNonNullChecks) {
                         return EntryCheckResult.okMap();
                     }
+                }
 
+                if (!keyIsNull && isNotExpectedType(expectedKeyType, key)) {
+                    return EntryCheckResult.foundInvalidType(EntryType.KEY, key);
+                }
+
+                if (!valueIsNull && isNotExpectedType(expectedValueType, value)) {
+                    return EntryCheckResult.foundInvalidType(EntryType.VALUE, value);
+                }
+
+                if (!keyIsNull || !valueIsNull) {
                     typeCheckCount++;
-                    if (isNotExpectedType(expectedValueType, value)) {
-                        return EntryCheckResult.foundInvalidType(EntryType.VALUE, value);
-                    }
-                    if (typeCheckCount >= maxElementTypeChecks) {
-                        break;
-                    }
-
-                } else if (nonNull(key) && isNull(value)) {
-                    nullCheckCount++;
-                    if (nullCheckCount > maxNonNullChecks) {
-                        return EntryCheckResult.okMap();
-                    }
-
-                    typeCheckCount++;
-                    if (isNotExpectedType(expectedKeyType, key)) {
-                        return EntryCheckResult.foundInvalidType(EntryType.KEY, key);
-                    }
-                    if (typeCheckCount >= maxElementTypeChecks) {
-                        break;
-                    }
-
-                } else if (isNull(key)) {  // key and value are both null
-                    nullCheckCount++;
-                    if (nullCheckCount > maxNonNullChecks) {
-                        return EntryCheckResult.okMap();
-                    }
-
-                } else {
-                    typeCheckCount++;
-                    if (isNotExpectedType(expectedKeyType, key)) {
-                        return EntryCheckResult.foundInvalidType(EntryType.KEY, key);
-                    } else if (isNotExpectedType(expectedValueType, value)) {
-                        return EntryCheckResult.foundInvalidType(EntryType.VALUE, value);
-                    }
                     if (typeCheckCount >= maxElementTypeChecks) {
                         break;
                     }

--- a/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
+++ b/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
@@ -5,6 +5,8 @@ import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
+import static org.kiwiproject.base.KiwiPreconditions.requirePositive;
+import static org.kiwiproject.base.KiwiPreconditions.requirePositiveOrZero;
 
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.VisibleForTesting;
@@ -97,8 +99,8 @@ public class KiwiCasts2 {
         private final int maxElementTypeChecks;
 
         private StandardCollectionCheckStrategy(int maxNonNullChecks, int maxElementTypeChecks) {
-            this.maxNonNullChecks = maxNonNullChecks;
-            this.maxElementTypeChecks = maxElementTypeChecks;
+            this.maxNonNullChecks = requirePositiveOrZero(maxNonNullChecks);
+            this.maxElementTypeChecks = requirePositive(maxElementTypeChecks);
         }
 
         public static StandardCollectionCheckStrategy ofDefaults() {
@@ -161,8 +163,8 @@ public class KiwiCasts2 {
         private final int maxElementTypeChecks;
 
         private StandardListCheckStrategy(int maxNonNullChecks, int maxElementTypeChecks) {
-            this.maxNonNullChecks = maxNonNullChecks;
-            this.maxElementTypeChecks = maxElementTypeChecks;
+            this.maxNonNullChecks = requirePositiveOrZero(maxNonNullChecks);
+            this.maxElementTypeChecks = requirePositive(maxElementTypeChecks);
         }
 
         public static StandardListCheckStrategy ofDefaults() {
@@ -225,8 +227,8 @@ public class KiwiCasts2 {
         private final int maxElementTypeChecks;
 
         private StandardSetCheckStrategy(int maxNonNullChecks, int maxElementTypeChecks) {
-            this.maxNonNullChecks = maxNonNullChecks;
-            this.maxElementTypeChecks = maxElementTypeChecks;
+            this.maxNonNullChecks = requirePositiveOrZero(maxNonNullChecks);
+            this.maxElementTypeChecks = requirePositive(maxElementTypeChecks);
         }
 
         public static StandardSetCheckStrategy ofDefaults() {
@@ -351,11 +353,11 @@ public class KiwiCasts2 {
     public static class StandardMapCheckStrategy implements MapCheckStrategy {
 
         private final int maxNonNullChecks;
-        private final int maxElementTypeChecks;
+        private final int maxEntryTypeChecks;
 
-        private StandardMapCheckStrategy(int maxNonNullChecks, int maxElementTypeChecks) {
-            this.maxNonNullChecks = maxNonNullChecks;
-            this.maxElementTypeChecks = maxElementTypeChecks;
+        private StandardMapCheckStrategy(int maxNonNullChecks, int maxEntryTypeChecks) {
+            this.maxNonNullChecks = requirePositiveOrZero(maxNonNullChecks);
+            this.maxEntryTypeChecks = requirePositive(maxEntryTypeChecks);
         }
 
         public static StandardMapCheckStrategy ofDefaults() {
@@ -368,7 +370,7 @@ public class KiwiCasts2 {
 
         @Override
         public <K, V> Map<K, V> checkEntries(Class<K> keyType, Class<V> valueType, Map<K, V> map) {
-            var checkResult = checkEntries(keyType, valueType, map, maxNonNullChecks, maxElementTypeChecks);
+            var checkResult = checkEntries(keyType, valueType, map, maxNonNullChecks, maxEntryTypeChecks);
 
             if (checkResult.ok()) {
                 return map;

--- a/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
+++ b/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
@@ -1,0 +1,332 @@
+package org.kiwiproject.beta.base;
+
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
+
+import com.google.common.annotations.Beta;
+import lombok.experimental.UtilityClass;
+import org.kiwiproject.collect.KiwiCollections;
+import org.kiwiproject.collect.KiwiMaps;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Utilities related to casting.
+ * <p>
+ * Some of these methods may be moved into {@code org.kiwiproject.base.KiwiCasts}
+ * in <a href="https://github.com/kiwiproject/kiwi">kiwi</a>. As of this writing,
+ * {@code KiwiCasts} is not released in kiwi. It is scheduled for the 4.11.0
+ * release. It was added to kiwi in
+ * <a href="https://github.com/kiwiproject/kiwi/commit/c67493352932985a61db68b839fca1566592efc0">this commit</a>.
+ */
+@Beta
+@UtilityClass
+public class KiwiCasts2 {
+
+    private static final int DEFAULT_MAX_NON_NULL_CHECKS = 10;
+    private static final int DEFAULT_MAX_TYPE_CHECKS = 10;
+
+    private static final CollectionCheckStrategy DEFAULT_COLLECTION_ELEMENT_CHECKING_STRATEGY =
+            new DefaultCollectionCheckStrategy();
+
+    private static final DefaultListCheckStrategy DEFAULT_LIST_ELEMENT_CHECKING_STRATEGY =
+            new DefaultListCheckStrategy();
+
+    private static final MapCheckStrategy DEFAULT_MAP_ELEMENT_CHECKING_STRATEGY =
+            new DefaultMapCheckStrategy();
+
+    private static final SetCheckStrategy DEFAULT_SET_ELEMENT_CHECKING_STRATEGY =
+            new DefaultSetCheckStrategy();
+
+    /**
+     * Performs an unchecked cast of the given object to the specified type.
+     * <p>
+     * <strong>NOTE:</strong> This method is copied directly from {@code KiwiCasts}
+     * in kiwi, since it is not currently in a released version of kiwi, and because
+     * it is necessary here.
+     *
+     * @param object the object to cast
+     * @param <T>    the type to cast to
+     * @return the object cast to the specified type
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T uncheckedCast(Object object) {
+        return (T) object;
+    }
+
+    public interface CollectionCheckStrategy {
+        <T> Collection<T> checkElements(Class<T> expectedType, Collection<T> coll) throws TypeMismatchException;
+    }
+
+    public static class DefaultCollectionCheckStrategy implements CollectionCheckStrategy {
+
+        @Override
+        public <T> Collection<T> checkElements(Class<T> expectedType, Collection<T> coll) {
+            var checkResult = checkElementsDefaultStrategy(expectedType, coll);
+
+            if (checkResult.ok()) {
+                return coll;
+            }
+
+            throw newCollectionTypeMismatch(Collection.class, expectedType, checkResult);
+        }
+    }
+
+    public static class StandardCollectionCheckStrategy implements CollectionCheckStrategy {
+
+        private final int maxNonNullChecks;
+        private final int maxElementTypeChecks;
+
+        private StandardCollectionCheckStrategy(int maxNonNullChecks, int maxElementTypeChecks) {
+            this.maxNonNullChecks = maxNonNullChecks;
+            this.maxElementTypeChecks = maxElementTypeChecks;
+        }
+
+        public static StandardCollectionCheckStrategy ofDefaults() {
+            return new StandardCollectionCheckStrategy(DEFAULT_MAX_NON_NULL_CHECKS, DEFAULT_MAX_TYPE_CHECKS);
+        }
+
+        public static StandardCollectionCheckStrategy of(int maxNonNullChecks, int maxElementTypeChecks) {
+            return new StandardCollectionCheckStrategy(maxNonNullChecks, maxElementTypeChecks);
+        }
+
+        @Override
+        public <T> Collection<T> checkElements(Class<T> expectedType, Collection<T> coll) throws TypeMismatchException {
+            if (KiwiCollections.isNullOrEmpty(coll)) {
+                // We can't verify type information about a null or empty collection
+                return coll;
+            }
+
+            var iterator = coll.iterator();
+            var nullCheckCount = 0;
+            var typeCheckCount = 0;
+
+            while (iterator.hasNext()) {
+                T value = iterator.next();
+
+                if (isNull(value)) {
+                    nullCheckCount++;
+                    if (nullCheckCount > maxNonNullChecks) {
+                        return coll;
+                    }
+                } else if (isNotExpectedType(expectedType, value)) {
+                    throw TypeMismatchException.forCollectionTypeMismatch(
+                            Collection.class,
+                            expectedType,
+                            value.getClass()
+                    );
+                } else {
+                    typeCheckCount++;
+                    if (typeCheckCount >= maxElementTypeChecks) {
+                        break;
+                    }
+                }
+            }
+
+            return coll;
+        }
+    }
+
+    public static <T> Collection<T> castToCollectionAndCheckElements(Class<T> expectedType, Object object) {
+        return castToCollectionAndCheckElements(expectedType, object, DEFAULT_COLLECTION_ELEMENT_CHECKING_STRATEGY);
+    }
+
+    public static <T> Collection<T> castToCollectionAndCheckElements(Class<T> expectedType,
+                                                                     Object object,
+                                                                     CollectionCheckStrategy strategy) {
+        checkExpectedTypeNotNull(expectedType);
+        try {
+            Collection<T> coll = uncheckedCast(object);
+            return strategy.checkElements(expectedType, coll);
+        } catch (ClassCastException e) {
+            throw TypeMismatchException.forTypeMismatch(Collection.class, e);
+        }
+    }
+
+    public interface ListCheckStrategy {
+        <T> List<T> checkElements(Class<T> expectedType, List<T> list) throws TypeMismatchException;
+    }
+
+    public static class DefaultListCheckStrategy implements ListCheckStrategy {
+
+        @Override
+        public <T> List<T> checkElements(Class<T> expectedType, List<T> list) {
+            var checkResult = checkElementsDefaultStrategy(expectedType, list);
+
+            if (checkResult.ok()) {
+                return list;
+            }
+
+            throw newCollectionTypeMismatch(List.class, expectedType, checkResult);
+        }
+    }
+
+    public static <T> List<T> castToListAndCheckElements(Class<T> expectedType, Object object) {
+        return castToListAndCheckElements(expectedType, object, DEFAULT_LIST_ELEMENT_CHECKING_STRATEGY);
+    }
+
+    public static <T> List<T> castToListAndCheckElements(Class<T> expectedType,
+                                                         Object object,
+                                                         ListCheckStrategy strategy) {
+        checkExpectedTypeNotNull(expectedType);
+        try {
+            List<T> list = uncheckedCast(object);
+            return strategy.checkElements(expectedType, list);
+        } catch (ClassCastException e) {
+            throw TypeMismatchException.forTypeMismatch(List.class, e);
+        }
+    }
+
+    public interface SetCheckStrategy {
+        <T> Set<T> checkElements(Class<T> expectedType, Set<T> set) throws TypeMismatchException;
+    }
+
+    public static class DefaultSetCheckStrategy implements SetCheckStrategy {
+
+        @Override
+        public <T> Set<T> checkElements(Class<T> expectedType, Set<T> set) {
+            var checkResult = checkElementsDefaultStrategy(expectedType, set);
+
+            if (checkResult.ok()) {
+                return set;
+            }
+
+            throw newCollectionTypeMismatch(Set.class, expectedType, checkResult);
+        }
+    }
+
+    record ElementCheckResult(boolean ok, Object invalidValue) {
+        static ElementCheckResult okCollection() {
+            return new ElementCheckResult(true, null);
+        }
+
+        static ElementCheckResult foundInvalidType(Object value) {
+            checkArgumentNotNull(value, "value must not be null");
+            return new ElementCheckResult(false, value);
+        }
+    }
+
+    private static <T> ElementCheckResult checkElementsDefaultStrategy(Class<?> expectedType, Collection<T> coll) {
+        if (KiwiCollections.isNullOrEmpty(coll)) {
+            // We can't verify type information about a null or empty collection
+            return ElementCheckResult.okCollection();
+        }
+
+        var maybeFirstNonNullValue = findFirstNonNullValueOrNull(coll);
+        if (isNull(maybeFirstNonNullValue)) {
+            // We didn't find a non-null value quickly, so give up
+            return ElementCheckResult.okCollection();
+        }
+
+        if (isNotExpectedType(expectedType, maybeFirstNonNullValue)) {
+            // We found a non-null value, but it is not assignable to the expected type, so the collection is invalid
+            return ElementCheckResult.foundInvalidType(maybeFirstNonNullValue);
+        }
+
+        return ElementCheckResult.okCollection();
+    }
+
+    private static TypeMismatchException newCollectionTypeMismatch(Class<?> collectionType, Class<?> expectedType, ElementCheckResult checkResult) {
+        return TypeMismatchException.forCollectionTypeMismatch(collectionType, expectedType, checkResult.invalidValue().getClass());
+    }
+
+    public static <T> Set<T> castToSetAndCheckElements(Class<T> expectedType, Object object) {
+        return castToSetAndCheckElements(expectedType, object, DEFAULT_SET_ELEMENT_CHECKING_STRATEGY);
+    }
+
+    public static <T> Set<T> castToSetAndCheckElements(Class<T> expectedType,
+                                                       Object object,
+                                                       SetCheckStrategy strategy) {
+        checkExpectedTypeNotNull(expectedType);
+        try {
+            Set<T> set = uncheckedCast(object);
+            return strategy.checkElements(expectedType, set);
+        } catch (ClassCastException e) {
+            throw TypeMismatchException.forTypeMismatch(Set.class, e);
+        }
+    }
+
+    private static <T> void checkExpectedTypeNotNull(Class<T> expectedType) {
+        checkArgumentNotNull(expectedType, "expectedType must not be null");
+    }
+
+    private static <T> T findFirstNonNullValueOrNull(Collection<T> coll) {
+        return coll.stream()
+                .filter(Objects::nonNull)
+                .limit(DEFAULT_MAX_NON_NULL_CHECKS)
+                .findFirst()
+                .orElse(null);
+    }
+
+    public interface MapCheckStrategy {
+        <K, V> Map<K, V> checkEntries(Class<K> keyType, Class<V> valueType, Map<K, V> map) throws TypeMismatchException;
+    }
+
+    public static class DefaultMapCheckStrategy implements MapCheckStrategy {
+
+        @Override
+        public <K, V> Map<K, V> checkEntries(Class<K> keyType, Class<V> valueType, Map<K, V> map) {
+            if (KiwiMaps.isNullOrEmpty(map)) {
+                // We can't verify type information about a null or empty map
+                return map;
+            }
+
+            // Find first non-null key with non-null value
+            Map.Entry<K, V> firstNonNullEntry = map.entrySet().stream()
+                    .filter(entry -> nonNull(entry.getKey()) && nonNull(entry.getValue()))
+                    .limit(DEFAULT_MAX_NON_NULL_CHECKS)
+                    .findFirst()
+                    .orElse(null);
+
+            if (isNull(firstNonNullEntry)) {
+                // We didn't find an entry with a non-null key and value quickly, so give up
+                return map;
+            }
+
+            var key = firstNonNullEntry.getKey();
+
+            if (isExpectedType(keyType, key)) {
+                var theValue = map.get(key);
+                if (isExpectedType(valueType, theValue)) {
+                    return map;
+                } else {
+                    throw TypeMismatchException.forMapValueTypeMismatch(valueType, theValue.getClass());
+                }
+            }
+
+            throw TypeMismatchException.forMapKeyTypeMismatch(keyType, key.getClass());
+        }
+    }
+
+    public static <K, V> Map<K, V> castToMapAndCheckEntries(Class<K> keyType, Class<V> valueType, Object object) {
+        return castToMapAndCheckEntries(keyType, valueType, object, DEFAULT_MAP_ELEMENT_CHECKING_STRATEGY);
+    }
+
+    public static <K, V> Map<K, V> castToMapAndCheckEntries(Class<K> keyType,
+                                                            Class<V> valueType,
+                                                            Object object,
+                                                            MapCheckStrategy strategy) {
+
+        checkArgumentNotNull(keyType, "keyType must not be null");
+        checkArgumentNotNull(valueType, "valueType must not be null");
+        try {
+            Map<K, V> map = uncheckedCast(object);
+            return strategy.checkEntries(keyType, valueType, map);
+        } catch (ClassCastException e) {
+            throw TypeMismatchException.forTypeMismatch(Map.class, e);
+        }
+    }
+
+    private static boolean isNotExpectedType(Class<?> expectedType, Object object) {
+        return !isExpectedType(expectedType, object);
+    }
+
+    private static boolean isExpectedType(Class<?> expectedType, Object object) {
+        return expectedType.isAssignableFrom(object.getClass());
+    }
+}

--- a/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
+++ b/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
@@ -64,18 +64,40 @@ public class KiwiCasts2 {
         return (T) object;
     }
 
+    /**
+     * Strategy interface for checking elements in a collection.
+     */
     public interface CollectionCheckStrategy {
+        /**
+         * Checks that elements in the collection are of the expected type.
+         *
+         * @param expectedType the expected type of elements in the collection
+         * @param coll the collection to check
+         * @param <T> the expected element type
+         * @return the original collection if all elements match the expected type
+         * @throws TypeMismatchException if an element is found with an incompatible type
+         */
         <T> Collection<T> checkElements(Class<T> expectedType, Collection<T> coll) throws TypeMismatchException;
     }
 
+    /**
+     * Default implementation of {@link CollectionCheckStrategy} that uses a standard strategy
+     * with default non-null checks and a single type check.
+     */
     public static class DefaultCollectionCheckStrategy implements CollectionCheckStrategy {
 
         private final StandardCollectionCheckStrategy strategy;
 
+        /**
+         * Constructs a new instance with default settings.
+         */
         public DefaultCollectionCheckStrategy() {
             strategy = StandardCollectionCheckStrategy.of(DEFAULT_MAX_NON_NULL_CHECKS, 1);
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public <T> Collection<T> checkElements(Class<T> expectedType, Collection<T> coll) {
             return strategy.checkElements(expectedType, coll);
@@ -93,6 +115,10 @@ public class KiwiCasts2 {
         }
     }
 
+    /**
+     * Standard implementation of {@link CollectionCheckStrategy} that allows configuring
+     * the number of non-null and type checks to perform.
+     */
     public static class StandardCollectionCheckStrategy implements CollectionCheckStrategy {
 
         private final int maxNonNullChecks;
@@ -103,14 +129,29 @@ public class KiwiCasts2 {
             this.maxElementTypeChecks = requirePositive(maxElementTypeChecks);
         }
 
+        /**
+         * Creates a new instance with default settings for maximum non-null and type checks.
+         *
+         * @return a new instance with default settings
+         */
         public static StandardCollectionCheckStrategy ofDefaults() {
             return new StandardCollectionCheckStrategy(DEFAULT_MAX_NON_NULL_CHECKS, DEFAULT_MAX_TYPE_CHECKS);
         }
 
+        /**
+         * Creates a new instance with the specified maximum non-null and type checks.
+         *
+         * @param maxNonNullChecks the maximum number of non-null checks to perform
+         * @param maxElementTypeChecks the maximum number of element type checks to perform
+         * @return a new instance with the specified settings
+         */
         public static StandardCollectionCheckStrategy of(int maxNonNullChecks, int maxElementTypeChecks) {
             return new StandardCollectionCheckStrategy(maxNonNullChecks, maxElementTypeChecks);
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public <T> Collection<T> checkElements(Class<T> expectedType, Collection<T> coll) throws TypeMismatchException {
             var checkResult = checkElementsStandardStrategy(expectedType, coll, maxNonNullChecks, maxElementTypeChecks);
@@ -123,10 +164,31 @@ public class KiwiCasts2 {
         }
     }
 
+    /**
+     * Casts the given object to a Collection and checks that its elements are of the expected type.
+     * Uses the default collection check strategy.
+     *
+     * @param expectedType the expected type of elements in the collection
+     * @param object the object to cast to a Collection
+     * @param <T> the expected element type
+     * @return the object cast to a Collection with elements of the expected type
+     * @throws TypeMismatchException if the object is not a Collection or contains elements of incompatible types
+     */
     public static <T> Collection<T> castToCollectionAndCheckElements(Class<T> expectedType, Object object) {
         return castToCollectionAndCheckElements(expectedType, object, DEFAULT_COLLECTION_CHECK_STRATEGY);
     }
 
+    /**
+     * Casts the given object to a Collection and checks that its elements are of the expected type
+     * using the specified check strategy.
+     *
+     * @param expectedType the expected type of elements in the collection
+     * @param object the object to cast to a Collection
+     * @param strategy the strategy to use for checking elements
+     * @param <T> the expected element type
+     * @return the object cast to a Collection with elements of the expected type
+     * @throws TypeMismatchException if the object is not a Collection or contains elements of incompatible types
+     */
     public static <T> Collection<T> castToCollectionAndCheckElements(Class<T> expectedType,
                                                                      Object object,
                                                                      CollectionCheckStrategy strategy) {
@@ -139,24 +201,50 @@ public class KiwiCasts2 {
         }
     }
 
+    /**
+     * Strategy interface for checking elements in a list.
+     */
     public interface ListCheckStrategy {
+        /**
+         * Checks that elements in the list are of the expected type.
+         *
+         * @param expectedType the expected type of elements in the list
+         * @param list the list to check
+         * @param <T> the expected element type
+         * @return the original list if all elements match the expected type
+         * @throws TypeMismatchException if an element is found with an incompatible type
+         */
         <T> List<T> checkElements(Class<T> expectedType, List<T> list) throws TypeMismatchException;
     }
 
+    /**
+     * Default implementation of {@link ListCheckStrategy} that uses a standard strategy
+     * with default non-null checks and a single type check.
+     */
     public static class DefaultListCheckStrategy implements ListCheckStrategy {
 
         private final StandardListCheckStrategy strategy;
 
+        /**
+         * Constructs a new instance with default settings.
+         */
         public DefaultListCheckStrategy() {
             strategy = StandardListCheckStrategy.of(DEFAULT_MAX_NON_NULL_CHECKS, 1);
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public <T> List<T> checkElements(Class<T> expectedType, List<T> list) {
             return strategy.checkElements(expectedType, list);
         }
     }
 
+    /**
+     * Standard implementation of {@link ListCheckStrategy} that allows configuring
+     * the number of non-null and type checks to perform.
+     */
     public static class StandardListCheckStrategy implements ListCheckStrategy {
 
         private final int maxNonNullChecks;
@@ -167,14 +255,29 @@ public class KiwiCasts2 {
             this.maxElementTypeChecks = requirePositive(maxElementTypeChecks);
         }
 
+        /**
+         * Creates a new instance with default settings for maximum non-null and type checks.
+         *
+         * @return a new instance with default settings
+         */
         public static StandardListCheckStrategy ofDefaults() {
             return new StandardListCheckStrategy(DEFAULT_MAX_NON_NULL_CHECKS, DEFAULT_MAX_TYPE_CHECKS);
         }
 
+        /**
+         * Creates a new instance with the specified maximum non-null and type checks.
+         *
+         * @param maxNonNullChecks the maximum number of non-null checks to perform
+         * @param maxElementTypeChecks the maximum number of element type checks to perform
+         * @return a new instance with the specified settings
+         */
         public static StandardListCheckStrategy of(int maxNonNullChecks, int maxElementTypeChecks) {
             return new StandardListCheckStrategy(maxNonNullChecks, maxElementTypeChecks);
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public <T> List<T> checkElements(Class<T> expectedType, List<T> list) throws TypeMismatchException {
             var checkResult = checkElementsStandardStrategy(expectedType, list, maxNonNullChecks, maxElementTypeChecks);
@@ -187,10 +290,31 @@ public class KiwiCasts2 {
         }
     }
 
+    /**
+     * Casts the given object to a List and checks that its elements are of the expected type.
+     * Uses the default list check strategy.
+     *
+     * @param expectedType the expected type of elements in the list
+     * @param object the object to cast to a List
+     * @param <T> the expected element type
+     * @return the object cast to a List with elements of the expected type
+     * @throws TypeMismatchException if the object is not a List or contains elements of incompatible types
+     */
     public static <T> List<T> castToListAndCheckElements(Class<T> expectedType, Object object) {
         return castToListAndCheckElements(expectedType, object, DEFAULT_LIST_CHECK_STRATEGY);
     }
 
+    /**
+     * Casts the given object to a List and checks that its elements are of the expected type
+     * using the specified check strategy.
+     *
+     * @param expectedType the expected type of elements in the list
+     * @param object the object to cast to a List
+     * @param strategy the strategy to use for checking elements
+     * @param <T> the expected element type
+     * @return the object cast to a List with elements of the expected type
+     * @throws TypeMismatchException if the object is not a List or contains elements of incompatible types
+     */
     public static <T> List<T> castToListAndCheckElements(Class<T> expectedType,
                                                          Object object,
                                                          ListCheckStrategy strategy) {
@@ -203,24 +327,50 @@ public class KiwiCasts2 {
         }
     }
 
+    /**
+     * Strategy interface for checking elements in a set.
+     */
     public interface SetCheckStrategy {
+        /**
+         * Checks that elements in the set are of the expected type.
+         *
+         * @param expectedType the expected type of elements in the set
+         * @param set the set to check
+         * @param <T> the expected element type
+         * @return the original set if all elements match the expected type
+         * @throws TypeMismatchException if an element is found with an incompatible type
+         */
         <T> Set<T> checkElements(Class<T> expectedType, Set<T> set) throws TypeMismatchException;
     }
 
+    /**
+     * Default implementation of {@link SetCheckStrategy} that uses a standard strategy
+     * with default non-null checks and a single type check.
+     */
     public static class DefaultSetCheckStrategy implements SetCheckStrategy {
 
         private final StandardSetCheckStrategy strategy;
 
+        /**
+         * Constructs a new instance with default settings.
+         */
         public DefaultSetCheckStrategy() {
             strategy = StandardSetCheckStrategy.of(DEFAULT_MAX_NON_NULL_CHECKS, 1);
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public <T> Set<T> checkElements(Class<T> expectedType, Set<T> set) {
             return strategy.checkElements(expectedType, set);
         }
     }
 
+    /**
+     * Standard implementation of {@link SetCheckStrategy} that allows configuring
+     * the number of non-null and type checks to perform.
+     */
     public static class StandardSetCheckStrategy implements SetCheckStrategy {
 
         private final int maxNonNullChecks;
@@ -231,14 +381,29 @@ public class KiwiCasts2 {
             this.maxElementTypeChecks = requirePositive(maxElementTypeChecks);
         }
 
+        /**
+         * Creates a new instance with default settings for maximum non-null and type checks.
+         *
+         * @return a new instance with default settings
+         */
         public static StandardSetCheckStrategy ofDefaults() {
             return new StandardSetCheckStrategy(DEFAULT_MAX_NON_NULL_CHECKS, DEFAULT_MAX_TYPE_CHECKS);
         }
 
+        /**
+         * Creates a new instance with the specified maximum non-null and type checks.
+         *
+         * @param maxNonNullChecks the maximum number of non-null checks to perform
+         * @param maxElementTypeChecks the maximum number of element type checks to perform
+         * @return a new instance with the specified settings
+         */
         public static StandardSetCheckStrategy of(int maxNonNullChecks, int maxElementTypeChecks) {
             return new StandardSetCheckStrategy(maxNonNullChecks, maxElementTypeChecks);
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public <T> Set<T> checkElements(Class<T> expectedType, Set<T> set) throws TypeMismatchException {
             var checkResult = checkElementsStandardStrategy(expectedType, set, maxNonNullChecks, maxElementTypeChecks);
@@ -290,10 +455,31 @@ public class KiwiCasts2 {
         return TypeMismatchException.forCollectionTypeMismatch(collectionType, expectedType, checkResult.invalidValue().getClass());
     }
 
+    /**
+     * Casts the given object to a Set and checks that its elements are of the expected type.
+     * Uses the default set check strategy.
+     *
+     * @param expectedType the expected type of elements in the set
+     * @param object the object to cast to a Set
+     * @param <T> the expected element type
+     * @return the object cast to a Set with elements of the expected type
+     * @throws TypeMismatchException if the object is not a Set or contains elements of incompatible types
+     */
     public static <T> Set<T> castToSetAndCheckElements(Class<T> expectedType, Object object) {
         return castToSetAndCheckElements(expectedType, object, DEFAULT_SET_CHECK_STRATEGY);
     }
 
+    /**
+     * Casts the given object to a Set and checks that its elements are of the expected type
+     * using the specified check strategy.
+     *
+     * @param expectedType the expected type of elements in the set
+     * @param object the object to cast to a Set
+     * @param strategy the strategy to use for checking elements
+     * @param <T> the expected element type
+     * @return the object cast to a Set with elements of the expected type
+     * @throws TypeMismatchException if the object is not a Set or contains elements of incompatible types
+     */
     public static <T> Set<T> castToSetAndCheckElements(Class<T> expectedType,
                                                        Object object,
                                                        SetCheckStrategy strategy) {
@@ -310,24 +496,52 @@ public class KiwiCasts2 {
         checkArgumentNotNull(expectedType, "expectedType must not be null");
     }
 
+    /**
+     * Strategy interface for checking entries in a map.
+     */
     public interface MapCheckStrategy {
+        /**
+         * Checks that keys and values in the map are of the expected types.
+         *
+         * @param keyType the expected type of keys in the map
+         * @param valueType the expected type of values in the map
+         * @param map the map to check
+         * @param <K> the expected key type
+         * @param <V> the expected value type
+         * @return the original map if all keys and values match the expected types
+         * @throws TypeMismatchException if a key or value is found with an incompatible type
+         */
         <K, V> Map<K, V> checkEntries(Class<K> keyType, Class<V> valueType, Map<K, V> map) throws TypeMismatchException;
     }
 
+    /**
+     * Default implementation of {@link MapCheckStrategy} that uses a standard strategy
+     * with default non-null checks and a single type check.
+     */
     public static class DefaultMapCheckStrategy implements MapCheckStrategy {
 
         private final StandardMapCheckStrategy strategy;
 
+        /**
+         * Constructs a new instance with default settings.
+         */
         public DefaultMapCheckStrategy() {
             strategy = StandardMapCheckStrategy.of(DEFAULT_MAX_NON_NULL_CHECKS, 1);
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public <K, V> Map<K, V> checkEntries(Class<K> keyType, Class<V> valueType, Map<K, V> map) {
             return strategy.checkEntries(keyType, valueType, map);
         }
     }
 
+    /**
+     * Standard implementation of {@link MapCheckStrategy} that allows configuring
+     * the number of non-null and type checks to perform.
+     */
     public static class StandardMapCheckStrategy implements MapCheckStrategy {
 
         private final int maxNonNullChecks;
@@ -338,14 +552,29 @@ public class KiwiCasts2 {
             this.maxEntryTypeChecks = requirePositive(maxEntryTypeChecks);
         }
 
+        /**
+         * Creates a new instance with default settings for maximum non-null and type checks.
+         *
+         * @return a new instance with default settings
+         */
         public static StandardMapCheckStrategy ofDefaults() {
             return new StandardMapCheckStrategy(DEFAULT_MAX_NON_NULL_CHECKS, DEFAULT_MAX_TYPE_CHECKS);
         }
 
+        /**
+         * Creates a new instance with the specified maximum non-null and type checks.
+         *
+         * @param maxNonNullChecks the maximum number of non-null checks to perform
+         * @param maxElementTypeChecks the maximum number of entry type checks to perform
+         * @return a new instance with the specified settings
+         */
         public static StandardMapCheckStrategy of(int maxNonNullChecks, int maxElementTypeChecks) {
             return new StandardMapCheckStrategy(maxNonNullChecks, maxElementTypeChecks);
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public <K, V> Map<K, V> checkEntries(Class<K> keyType, Class<V> valueType, Map<K, V> map) {
             var checkResult = checkEntriesInternal(keyType, valueType, map);
@@ -431,10 +660,35 @@ public class KiwiCasts2 {
         }
     }
 
+    /**
+     * Casts the given object to a Map and checks that its keys and values are of the expected types.
+     * Uses the default map check strategy.
+     *
+     * @param keyType the expected type of keys in the map
+     * @param valueType the expected type of values in the map
+     * @param object the object to cast to a Map
+     * @param <K> the expected key type
+     * @param <V> the expected value type
+     * @return the object cast to a Map with keys and values of the expected types
+     * @throws TypeMismatchException if the object is not a Map or contains keys or values of incompatible types
+     */
     public static <K, V> Map<K, V> castToMapAndCheckEntries(Class<K> keyType, Class<V> valueType, Object object) {
         return castToMapAndCheckEntries(keyType, valueType, object, DEFAULT_MAP_CHECK_STRATEGY);
     }
 
+    /**
+     * Casts the given object to a Map and checks that its keys and values are of the expected types
+     * using the specified check strategy.
+     *
+     * @param keyType the expected type of keys in the map
+     * @param valueType the expected type of values in the map
+     * @param object the object to cast to a Map
+     * @param strategy the strategy to use for checking entries
+     * @param <K> the expected key type
+     * @param <V> the expected value type
+     * @return the object cast to a Map with keys and values of the expected types
+     * @throws TypeMismatchException if the object is not a Map or contains keys or values of incompatible types
+     */
     public static <K, V> Map<K, V> castToMapAndCheckEntries(Class<K> keyType,
                                                             Class<V> valueType,
                                                             Object object,

--- a/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
+++ b/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
@@ -65,15 +65,22 @@ public class KiwiCasts2 {
 
     public static class DefaultCollectionCheckStrategy implements CollectionCheckStrategy {
 
+        private final StandardCollectionCheckStrategy strategy;
+
+        public DefaultCollectionCheckStrategy() {
+            strategy = StandardCollectionCheckStrategy.of(DEFAULT_MAX_NON_NULL_CHECKS, 1);
+        }
+
         @Override
         public <T> Collection<T> checkElements(Class<T> expectedType, Collection<T> coll) {
-            var checkResult = checkElementsDefaultStrategy(expectedType, coll);
-
-            if (checkResult.ok()) {
-                return coll;
-            }
-
-            throw newCollectionTypeMismatch(Collection.class, expectedType, checkResult);
+//            var checkResult = checkElementsDefaultStrategy(expectedType, coll);
+//
+//            if (checkResult.ok()) {
+//                return coll;
+//            }
+//
+//            throw newCollectionTypeMismatch(Collection.class, expectedType, checkResult);
+            return strategy.checkElements(expectedType, coll);
         }
     }
 

--- a/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
+++ b/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
@@ -208,7 +208,7 @@ public class KiwiCasts2 {
             Collection<T> coll = uncheckedCast(object);
             return strategy.checkElements(expectedType, coll);
         } catch (ClassCastException e) {
-            throw TypeMismatchException.forExpectedTypeWithCause(Collection.class, e);
+            throw typeMismatchExceptionForUnexpectedType(Collection.class, object, e);
         }
     }
 
@@ -338,7 +338,7 @@ public class KiwiCasts2 {
             List<T> list = uncheckedCast(object);
             return strategy.checkElements(expectedType, list);
         } catch (ClassCastException e) {
-            throw TypeMismatchException.forExpectedTypeWithCause(List.class, e);
+            throw typeMismatchExceptionForUnexpectedType(List.class, object, e);
         }
     }
 
@@ -507,7 +507,7 @@ public class KiwiCasts2 {
             Set<T> set = uncheckedCast(object);
             return strategy.checkElements(expectedType, set);
         } catch (ClassCastException e) {
-            throw TypeMismatchException.forExpectedTypeWithCause(Set.class, e);
+           throw typeMismatchExceptionForUnexpectedType(Set.class, object, e);
         }
     }
 
@@ -727,7 +727,7 @@ public class KiwiCasts2 {
             Map<K, V> map = uncheckedCast(object);
             return strategy.checkEntries(keyType, valueType, map);
         } catch (ClassCastException e) {
-            throw TypeMismatchException.forExpectedTypeWithCause(Map.class, e);
+            throw typeMismatchExceptionForUnexpectedType(Map.class, object, e);
         }
     }
 
@@ -737,5 +737,17 @@ public class KiwiCasts2 {
 
     private static boolean isExpectedType(Class<?> expectedType, Object object) {
         return expectedType.isAssignableFrom(object.getClass());
+    }
+
+    private static <T> TypeMismatchException typeMismatchExceptionForUnexpectedType(
+            Class<T> expectedType, 
+            Object object,
+            ClassCastException e) {
+
+        if (isNull(object)) {
+            return TypeMismatchException.forExpectedTypeWithCause(expectedType, e);
+        }
+
+        return TypeMismatchException.forUnexpectedTypeWithCause(expectedType, object.getClass(), e);
     }
 }

--- a/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
+++ b/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
@@ -573,7 +573,7 @@ public class KiwiCasts2 {
         }
 
         /**
-         * Creates a new instance with default settings for maximum non-null and type checks..
+         * Creates a new instance with default settings for maximum non-null and type checks.
          * <p>
          * Uses {@link #DEFAULT_MAX_NON_NULL_CHECKS} and {@link #DEFAULT_MAX_TYPE_CHECKS} as the
          * values for {@code maxNonNullChecks} and {@code maxElementTypeChecks}, respectively.

--- a/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
+++ b/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
@@ -370,7 +370,7 @@ public class KiwiCasts2 {
 
         @Override
         public <K, V> Map<K, V> checkEntries(Class<K> keyType, Class<V> valueType, Map<K, V> map) {
-            var checkResult = checkEntries(keyType, valueType, map, maxNonNullChecks, maxEntryTypeChecks);
+            var checkResult = checkEntriesInternal(keyType, valueType, map);
 
             if (checkResult.ok()) {
                 return map;
@@ -409,12 +409,10 @@ public class KiwiCasts2 {
             }
         }
 
-        private static <K, V> EntryCheckResult checkEntries(
+        private <K, V> EntryCheckResult checkEntriesInternal(
                 Class<?> expectedKeyType,
                 Class<?> expectedValueType,
-                Map<K, V> map,
-                int maxNonNullChecks,
-                int maxEntryTypeChecks) {
+                Map<K, V> map) {
 
             if (KiwiMaps.isNullOrEmpty(map)) {
                 // We can't verify type information about a null or empty map

--- a/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
+++ b/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
@@ -281,26 +281,6 @@ public class KiwiCasts2 {
         }
     }
 
-//    private static <T> ElementCheckResult checkElementsDefaultStrategy(Class<?> expectedType, Collection<T> coll) {
-//        if (KiwiCollections.isNullOrEmpty(coll)) {
-//            // We can't verify type information about a null or empty collection
-//            return ElementCheckResult.okCollection();
-//        }
-//
-//        var maybeFirstNonNullValue = findFirstNonNullValueOrNull(coll);
-//        if (isNull(maybeFirstNonNullValue)) {
-//            // We didn't find a non-null value quickly, so give up
-//            return ElementCheckResult.okCollection();
-//        }
-//
-//        if (isNotExpectedType(expectedType, maybeFirstNonNullValue)) {
-//            // We found a non-null value, but it is not assignable to the expected type, so the collection is invalid
-//            return ElementCheckResult.foundInvalidType(maybeFirstNonNullValue);
-//        }
-//
-//        return ElementCheckResult.okCollection();
-//    }
-
     private static TypeMismatchException newCollectionTypeMismatch(Class<?> collectionType, Class<?> expectedType, ElementCheckResult checkResult) {
         return TypeMismatchException.forCollectionTypeMismatch(collectionType, expectedType, checkResult.invalidValue().getClass());
     }
@@ -324,22 +304,6 @@ public class KiwiCasts2 {
     private static <T> void checkExpectedTypeNotNull(Class<T> expectedType) {
         checkArgumentNotNull(expectedType, "expectedType must not be null");
     }
-
-//    private static <T> T findFirstNonNullValueOrNull(Collection<T> coll) {
-//        return coll.stream()
-//                .filter(Objects::nonNull)
-//                .limit(DEFAULT_MAX_NON_NULL_CHECKS)
-//                .findFirst()
-//                .orElse(null);
-//    }
-
-//    private static <T> T findFirstNonNullValueOrNull(Iterator<T> iterator) {
-//        return Streams.stream(iterator)
-//                .filter(Objects::nonNull)
-//                .limit(DEFAULT_MAX_NON_NULL_CHECKS)
-//                .findFirst()
-//                .orElse(null);
-//    }
 
     public interface MapCheckStrategy {
         <K, V> Map<K, V> checkEntries(Class<K> keyType, Class<V> valueType, Map<K, V> map) throws TypeMismatchException;

--- a/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
+++ b/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
@@ -476,7 +476,7 @@ public class KiwiCasts2 {
 
     /**
      * Casts the given object to a Set and checks that its elements are of the expected type.
-     * Uses the default set check strategy.
+     * Uses {@link DefaultSetCheckStrategy} as the set check strategy.
      *
      * @param expectedType the expected type of elements in the set
      * @param object the object to cast to a Set
@@ -534,8 +534,9 @@ public class KiwiCasts2 {
     }
 
     /**
-     * Default implementation of {@link MapCheckStrategy} that uses a standard strategy
-     * with default non-null checks and a single type check.
+     * Default implementation of {@link MapCheckStrategy} that uses
+     * {@link #DEFAULT_MAX_NON_NULL_CHECKS} as the maximum non-null checks
+     * and checks only one (non-null) entry in the map.
      */
     public static class DefaultMapCheckStrategy implements MapCheckStrategy {
 
@@ -572,9 +573,12 @@ public class KiwiCasts2 {
         }
 
         /**
-         * Creates a new instance with default settings for maximum non-null and type checks.
+         * Creates a new instance with default settings for maximum non-null and type checks..
+         * <p>
+         * Uses {@link #DEFAULT_MAX_NON_NULL_CHECKS} and {@link #DEFAULT_MAX_TYPE_CHECKS} as the
+         * values for {@code maxNonNullChecks} and {@code maxElementTypeChecks}, respectively.
          *
-         * @return a new instance with default settings
+         * @return a new instance
          */
         public static StandardMapCheckStrategy ofDefaults() {
             return new StandardMapCheckStrategy(DEFAULT_MAX_NON_NULL_CHECKS, DEFAULT_MAX_TYPE_CHECKS);
@@ -681,7 +685,7 @@ public class KiwiCasts2 {
 
     /**
      * Casts the given object to a Map and checks that its keys and values are of the expected types.
-     * Uses the default map check strategy.
+     * Uses {@link DefaultMapCheckStrategy} as the map check strategy.
      *
      * @param keyType the expected type of keys in the map
      * @param valueType the expected type of values in the map

--- a/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
+++ b/src/main/java/org/kiwiproject/beta/base/KiwiCasts2.java
@@ -73,13 +73,6 @@ public class KiwiCasts2 {
 
         @Override
         public <T> Collection<T> checkElements(Class<T> expectedType, Collection<T> coll) {
-//            var checkResult = checkElementsDefaultStrategy(expectedType, coll);
-//
-//            if (checkResult.ok()) {
-//                return coll;
-//            }
-//
-//            throw newCollectionTypeMismatch(Collection.class, expectedType, checkResult);
             return strategy.checkElements(expectedType, coll);
         }
     }

--- a/src/main/java/org/kiwiproject/beta/base/TypeMismatchException.java
+++ b/src/main/java/org/kiwiproject/beta/base/TypeMismatchException.java
@@ -57,39 +57,39 @@ public class TypeMismatchException extends RuntimeException {
     /**
      * Factory method to create a new instance with a standardized message for a type mismatch.
      *
-     * @param valueType the expected type of the value
-     * @param cause     the ClassCastException that occurred during the cast attempt
+     * @param expectedType the expected type of the value
+     * @param cause        the ClassCastException that occurred during the cast attempt
      * @return a new instance with a descriptive message
      */
-    public static TypeMismatchException forTypeMismatch(Class<?> valueType, ClassCastException cause) {
-        return new TypeMismatchException(f("Cannot cast value to type {}", valueType.getName()), cause);
+    public static TypeMismatchException forExpectedTypeWithCause(Class<?> expectedType, ClassCastException cause) {
+        return new TypeMismatchException(f("Cannot cast value to type {}", expectedType.getName()), cause);
     }
 
     /**
      * Factory method to create a new instance with a standardized message for a type mismatch.
      *
-     * @param valueType      the expected type of the value
+     * @param expectedType   the expected type of the value
      * @param unexpectedType the actual type of the value
      * @return a new instance with a descriptive message
      */
-    public static TypeMismatchException forTypeMismatch(Class<?> valueType, Class<?> unexpectedType) {
+    public static TypeMismatchException forUnexpectedType(Class<?> expectedType, Class<?> unexpectedType) {
         return new TypeMismatchException(f("Cannot cast value of type {} to type {}",
-                unexpectedType.getName(), valueType.getName()));
+                unexpectedType.getName(), expectedType.getName()));
     }
 
      /**
      * Factory method to create a new instance with a standardized message for a type mismatch.
      *
-     * @param valueType      the expected type of the value
+     * @param expectedType   the expected type of the value
      * @param unexpectedType the actual type of the value
      * @param cause          the ClassCastException that occurred during the cast attempt
      * @return a new instance with a descriptive message
      */
-    public static TypeMismatchException forTypeMismatch(Class<?> valueType,
-                                                        Class<?> unexpectedType,
-                                                        ClassCastException cause) {
+    public static TypeMismatchException forUnexpectedTypeWithCause(Class<?> expectedType,
+                                                                   Class<?> unexpectedType,
+                                                                   ClassCastException cause) {
         var message = f("Cannot cast value of type {} to type {}",
-                unexpectedType.getName(), valueType.getName());
+                unexpectedType.getName(), expectedType.getName());
         return new TypeMismatchException(message, cause);
     }
 
@@ -98,43 +98,43 @@ public class TypeMismatchException extends RuntimeException {
      * on a collection element.
      * 
      * @param collectionType the type of collection, such as Collection, List, or Set
-     * @param valueType      the expected type of the collection elements
-     * @param unexpectedType the unexpected type found in the collection
+     * @param expectedType   the expected type of the collection elements
+     * @param unexpectedType the actual type found in the collection
      * @return a new instance with a descriptive message
      */
-    public static TypeMismatchException forCollectionTypeMismatch(Class<?> collectionType,
-                                                                  Class<?> valueType,
-                                                                  Class<?> unexpectedType) {
+    public static TypeMismatchException forUnexpectedCollectionElementType(Class<?> collectionType,
+                                                                           Class<?> expectedType,
+                                                                           Class<?> unexpectedType) {
         var message = f("Expected {} to contain elements of type {}, but found element of type {}",
-                collectionType.getName(), valueType.getName(), unexpectedType.getName());
+                collectionType.getName(), expectedType.getName(), unexpectedType.getName());
         return new TypeMismatchException(message);
     }
 
     /**
      * Factory method to create a new instance with a standardized message for a map key type mismatch.
      * 
-     * @param keyType           the expected type of keys in the map
-     * @param unexpectedKeyType the unexpected type of key found in the map
+     * @param expectedKeyType   the expected type of keys in the map
+     * @param unexpectedKeyType the actual type of key found in the map
      * @return a new instance with a descriptive message
      */
-    public static TypeMismatchException forMapKeyTypeMismatch(Class<?> keyType,
-                                                              Class<?> unexpectedKeyType) {
+    public static TypeMismatchException forUnexpectedMapKeyType(Class<?> expectedKeyType,
+                                                                Class<?> unexpectedKeyType) {
         var message = f("Expected Map to contain keys of type {}, but found key of type {}",
-                keyType.getName(), unexpectedKeyType.getName());
+                expectedKeyType.getName(), unexpectedKeyType.getName());
         return new TypeMismatchException(message);
     }
 
     /**
      * Factory method to create a new instance with a standardized message for a map value type mismatch.
      * 
-     * @param valueType           the expected type of values in the map
-     * @param unexpectedValueType the unexpected type of value found in the map
+     * @param expectedValueType   the expected type of values in the map
+     * @param unexpectedValueType the actual type of value found in the map
      * @return a new instance with a descriptive message
      */
-    public static TypeMismatchException forMapValueTypeMismatch(Class<?> valueType,
-                                                                Class<?> unexpectedValueType) {
+    public static TypeMismatchException forUnexpectedMapValueType(Class<?> expectedValueType,
+                                                                  Class<?> unexpectedValueType) {
         var message = f("Expected Map to contain values of type {}, but found value of type {}",
-                valueType.getName(), unexpectedValueType.getName());
+                expectedValueType.getName(), unexpectedValueType.getName());
         return new TypeMismatchException(message);
     }
 }

--- a/src/main/java/org/kiwiproject/beta/base/TypeMismatchException.java
+++ b/src/main/java/org/kiwiproject/beta/base/TypeMismatchException.java
@@ -1,0 +1,80 @@
+package org.kiwiproject.beta.base;
+
+import static org.kiwiproject.base.KiwiStrings.f;
+
+import com.google.common.annotations.Beta;
+
+/**
+ * Exception thrown when a value cannot be cast to the expected type.
+ */
+@Beta
+public class TypeMismatchException extends RuntimeException {
+
+    /**
+     * Constructs a new instance with no detail message.
+     */
+    public TypeMismatchException() {
+    }
+
+    /**
+     * Constructs a new instance with the specified detail message.
+     *
+     * @param message the detail message
+     */
+    public TypeMismatchException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new instance with the specified detail message and cause.
+     *
+     * @param message the detail message
+     * @param cause   the cause
+     */
+    public TypeMismatchException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a new instance with the specified cause and a detail message
+     * of {@code (cause==null ? null : cause.toString())}.
+     *
+     * @param cause the cause
+     */
+    public TypeMismatchException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Factory method to create a new instance with a standardized message for a type mismatch.
+     *
+     * @param valueType the expected type of the value
+     * @param cause     the ClassCastException that occurred during the cast attempt
+     * @return a new instance with a descriptive message
+     */
+    public static TypeMismatchException forTypeMismatch(Class<?> valueType, ClassCastException cause) {
+        return new TypeMismatchException(f("Cannot cast value to type {}", valueType.getName()), cause);
+    }
+
+    public static TypeMismatchException forCollectionTypeMismatch(Class<?> collectionType,
+                                                                  Class<?> valueType,
+                                                                  Class<?> unexpectedType) {
+        var message = f("Expected {} to contain elements of type {}, but found element of type {}",
+                collectionType.getName(), valueType.getName(), unexpectedType.getName());
+        return new TypeMismatchException(message);
+    }
+
+    public static TypeMismatchException forMapKeyTypeMismatch(Class<?> keyType,
+                                                              Class<?> unexpectedKeyType) {
+        var message = f("Expected Map to contain keys of type {}, but found key of type {}",
+                keyType.getName(), unexpectedKeyType.getName());
+        return new TypeMismatchException(message);
+    }
+
+    public static TypeMismatchException forMapValueTypeMismatch(Class<?> valueType,
+                                                                Class<?> unexpectedValueType) {
+        var message = f("Expected Map to contain values of type {}, but found value of type {}",
+                valueType.getName(), unexpectedValueType.getName());
+        return new TypeMismatchException(message);
+    }
+}

--- a/src/main/java/org/kiwiproject/beta/base/TypeMismatchException.java
+++ b/src/main/java/org/kiwiproject/beta/base/TypeMismatchException.java
@@ -6,6 +6,15 @@ import com.google.common.annotations.Beta;
 
 /**
  * Exception thrown when a value cannot be cast to the expected type.
+ * <p>
+ * This exists mainly to provide more information in certain situations
+ * than {@link ClassCastException} does. For example, when checking that
+ * a List contains only Integer values but a Double is found.
+ * <p>
+ * While you can construct an instance using the "standard" constructors,
+ * it is preferable to create instances the factory methods which can
+ * provide better semantic meaning, and better messages describing the
+ * problem.
  */
 @Beta
 public class TypeMismatchException extends RuntimeException {
@@ -56,6 +65,43 @@ public class TypeMismatchException extends RuntimeException {
         return new TypeMismatchException(f("Cannot cast value to type {}", valueType.getName()), cause);
     }
 
+    /**
+     * Factory method to create a new instance with a standardized message for a type mismatch.
+     *
+     * @param valueType      the expected type of the value
+     * @param unexpectedType the actual type of the value
+     * @return a new instance with a descriptive message
+     */
+    public static TypeMismatchException forTypeMismatch(Class<?> valueType, Class<?> unexpectedType) {
+        return new TypeMismatchException(f("Cannot cast value of type {} to type {}",
+                unexpectedType.getName(), valueType.getName()));
+    }
+
+     /**
+     * Factory method to create a new instance with a standardized message for a type mismatch.
+     *
+     * @param valueType      the expected type of the value
+     * @param unexpectedType the actual type of the value
+     * @param cause          the ClassCastException that occurred during the cast attempt
+     * @return a new instance with a descriptive message
+     */
+    public static TypeMismatchException forTypeMismatch(Class<?> valueType,
+                                                        Class<?> unexpectedType,
+                                                        ClassCastException cause) {
+        var message = f("Cannot cast value of type {} to type {}",
+                unexpectedType.getName(), valueType.getName());
+        return new TypeMismatchException(message, cause);
+    }
+
+    /**
+     * Factory method to create a new instance with a standardized message for a type mismatch
+     * on a collection element.
+     * 
+     * @param collectionType the type of collection, such as Collection, List, or Set
+     * @param valueType      the expected type of the collection elements
+     * @param unexpectedType the unexpected type found in the collection
+     * @return a new instance with a descriptive message
+     */
     public static TypeMismatchException forCollectionTypeMismatch(Class<?> collectionType,
                                                                   Class<?> valueType,
                                                                   Class<?> unexpectedType) {
@@ -64,6 +110,13 @@ public class TypeMismatchException extends RuntimeException {
         return new TypeMismatchException(message);
     }
 
+    /**
+     * Factory method to create a new instance with a standardized message for a map key type mismatch.
+     * 
+     * @param keyType           the expected type of keys in the map
+     * @param unexpectedKeyType the unexpected type of key found in the map
+     * @return a new instance with a descriptive message
+     */
     public static TypeMismatchException forMapKeyTypeMismatch(Class<?> keyType,
                                                               Class<?> unexpectedKeyType) {
         var message = f("Expected Map to contain keys of type {}, but found key of type {}",
@@ -71,6 +124,13 @@ public class TypeMismatchException extends RuntimeException {
         return new TypeMismatchException(message);
     }
 
+    /**
+     * Factory method to create a new instance with a standardized message for a map value type mismatch.
+     * 
+     * @param valueType           the expected type of values in the map
+     * @param unexpectedValueType the unexpected type of value found in the map
+     * @return a new instance with a descriptive message
+     */
     public static TypeMismatchException forMapValueTypeMismatch(Class<?> valueType,
                                                                 Class<?> unexpectedValueType) {
         var message = f("Expected Map to contain values of type {}, but found value of type {}",

--- a/src/main/java/org/kiwiproject/beta/base/TypeMismatchException.java
+++ b/src/main/java/org/kiwiproject/beta/base/TypeMismatchException.java
@@ -69,28 +69,28 @@ public class TypeMismatchException extends RuntimeException {
     /**
      * Factory method to create a new instance with a standardized message for a type mismatch.
      *
-     * @param expectedType   the expected type of the value
-     * @param unexpectedType the actual type of the value
+     * @param expectedType the expected type of the value
+     * @param actualType   the actual type of the value
      * @return a new instance with a descriptive message
      */
-    public static TypeMismatchException forUnexpectedType(Class<?> expectedType, Class<?> unexpectedType) {
+    public static TypeMismatchException forUnexpectedType(Class<?> expectedType, Class<?> actualType) {
         return new TypeMismatchException(f("Cannot cast value of type {} to type {}",
-                unexpectedType.getName(), expectedType.getName()));
+                actualType.getName(), expectedType.getName()));
     }
 
      /**
      * Factory method to create a new instance with a standardized message for a type mismatch.
      *
-     * @param expectedType   the expected type of the value
-     * @param unexpectedType the actual type of the value
-     * @param cause          the ClassCastException that occurred during the cast attempt
+     * @param expectedType the expected type of the value
+     * @param actualType   the actual type of the value
+     * @param cause        the ClassCastException that occurred during the cast attempt
      * @return a new instance with a descriptive message
      */
     public static TypeMismatchException forUnexpectedTypeWithCause(Class<?> expectedType,
-                                                                   Class<?> unexpectedType,
+                                                                   Class<?> actualType,
                                                                    ClassCastException cause) {
         var message = f("Cannot cast value of type {} to type {}",
-                unexpectedType.getName(), expectedType.getName());
+                actualType.getName(), expectedType.getName());
         return new TypeMismatchException(message, cause);
     }
 
@@ -100,42 +100,42 @@ public class TypeMismatchException extends RuntimeException {
      * 
      * @param collectionType the type of collection, such as Collection, List, or Set
      * @param expectedType   the expected type of the collection elements
-     * @param unexpectedType the actual type found in the collection
+     * @param actualType     the actual type found in the collection
      * @return a new instance with a descriptive message
      */
     public static TypeMismatchException forUnexpectedCollectionElementType(Class<?> collectionType,
                                                                            Class<?> expectedType,
-                                                                           Class<?> unexpectedType) {
+                                                                           Class<?> actualType) {
         var message = f("Expected {} to contain elements of type {}, but found element of type {}",
-                collectionType.getName(), expectedType.getName(), unexpectedType.getName());
+                collectionType.getName(), expectedType.getName(), actualType.getName());
         return new TypeMismatchException(message);
     }
 
     /**
      * Factory method to create a new instance with a standardized message for a map key type mismatch.
      * 
-     * @param expectedKeyType   the expected type of keys in the map
-     * @param unexpectedKeyType the actual type of key found in the map
+     * @param expectedKeyType the expected type of keys in the map
+     * @param actualKeyType   the actual type of key found in the map
      * @return a new instance with a descriptive message
      */
     public static TypeMismatchException forUnexpectedMapKeyType(Class<?> expectedKeyType,
-                                                                Class<?> unexpectedKeyType) {
+                                                                Class<?> actualKeyType) {
         var message = f("Expected Map to contain keys of type {}, but found key of type {}",
-                expectedKeyType.getName(), unexpectedKeyType.getName());
+                expectedKeyType.getName(), actualKeyType.getName());
         return new TypeMismatchException(message);
     }
 
     /**
      * Factory method to create a new instance with a standardized message for a map value type mismatch.
      * 
-     * @param expectedValueType   the expected type of values in the map
-     * @param unexpectedValueType the actual type of value found in the map
+     * @param expectedValueType the expected type of values in the map
+     * @param actualValueType   the actual type of value found in the map
      * @return a new instance with a descriptive message
      */
     public static TypeMismatchException forUnexpectedMapValueType(Class<?> expectedValueType,
-                                                                  Class<?> unexpectedValueType) {
+                                                                  Class<?> actualValueType) {
         var message = f("Expected Map to contain values of type {}, but found value of type {}",
-                expectedValueType.getName(), unexpectedValueType.getName());
+                expectedValueType.getName(), actualValueType.getName());
         return new TypeMismatchException(message);
     }
 }

--- a/src/main/java/org/kiwiproject/beta/base/TypeMismatchException.java
+++ b/src/main/java/org/kiwiproject/beta/base/TypeMismatchException.java
@@ -9,7 +9,8 @@ import com.google.common.annotations.Beta;
  * <p>
  * This exists mainly to provide more information in certain situations
  * than {@link ClassCastException} does. For example, when checking that
- * a List contains only Integer values but a Double is found.
+ * a List contains only Integer values but a Double is found. Or when
+ * checking that a Map contains the expected key and value types.
  * <p>
  * While you can construct an instance using the "standard" constructors,
  * it is preferable to create instances the factory methods which can

--- a/src/main/java/org/kiwiproject/beta/base/TypeMismatchException.java
+++ b/src/main/java/org/kiwiproject/beta/base/TypeMismatchException.java
@@ -1,5 +1,6 @@
 package org.kiwiproject.beta.base;
 
+import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
 import static org.kiwiproject.base.KiwiStrings.f;
 
 import com.google.common.annotations.Beta;
@@ -9,73 +10,52 @@ import com.google.common.annotations.Beta;
  * <p>
  * This exists mainly to provide more information in certain situations
  * than {@link ClassCastException} does. For example, when checking that
- * a List contains only Integer values but a Double is found. Or when
+ * a List contains only Integer values, but a Double is found. Or when
  * checking that a Map contains the expected key and value types.
- * <p>
- * While you can construct an instance using the "standard" constructors,
- * it is preferable to create instances the factory methods which can
- * provide better semantic meaning, and better messages describing the
- * problem.
  */
 @Beta
 public class TypeMismatchException extends RuntimeException {
 
-    /**
-     * Constructs a new instance with no detail message.
-     */
-    public TypeMismatchException() {
-    }
+    private final Class<?> expectedType;
+    private final Class<?> actualType;
 
-    /**
-     * Constructs a new instance with the specified detail message.
-     *
-     * @param message the detail message
-     */
-    public TypeMismatchException(String message) {
-        super(message);
-    }
-
-    /**
-     * Constructs a new instance with the specified detail message and cause.
-     *
-     * @param message the detail message
-     * @param cause   the cause
-     */
-    public TypeMismatchException(String message, Throwable cause) {
+    private TypeMismatchException(String message,
+                                  Class<?> expectedType,
+                                  Class<?> actualType,
+                                  Throwable cause) {
         super(message, cause);
+        this.expectedType = requireNotNull(expectedType, "expectedType must not be null");
+        this.actualType = requireNotNull(actualType, "actualType must not be null");
     }
 
     /**
-     * Constructs a new instance with the specified cause and a detail message
-     * of {@code (cause==null ? null : cause.toString())}.
+     * Gets the expected type of the value that caused the type mismatch.
      *
-     * @param cause the cause
+     * @return the Class object representing the expected type
      */
-    public TypeMismatchException(Throwable cause) {
-        super(cause);
+    public Class<?> expectedType() {
+        return expectedType;
     }
 
     /**
-     * Factory method to create a new instance with a standardized message for a type mismatch.
+     * Gets the actual type of the value that caused the type mismatch.
      *
-     * @param expectedType the expected type of the value
-     * @param cause        the ClassCastException that occurred during the cast attempt
-     * @return a new instance with a descriptive message
+     * @return the Class object representing the actual type
      */
-    public static TypeMismatchException forExpectedTypeWithCause(Class<?> expectedType, ClassCastException cause) {
-        return new TypeMismatchException(f("Cannot cast value to type {}", expectedType.getName()), cause);
+    public Class<?> actualType() {
+        return actualType;
     }
 
     /**
-     * Factory method to create a new instance with a standardized message for a type mismatch.
+     * Factory method to create a new instance with a standardized message for a type mismatch and no cause.
      *
      * @param expectedType the expected type of the value
      * @param actualType   the actual type of the value
      * @return a new instance with a descriptive message
      */
     public static TypeMismatchException forUnexpectedType(Class<?> expectedType, Class<?> actualType) {
-        return new TypeMismatchException(f("Cannot cast value of type {} to type {}",
-                actualType.getName(), expectedType.getName()));
+        var message = f("Cannot cast value of type {} to type {}", actualType.getName(), expectedType.getName());
+        return TypeMismatchException.forUnexpectedTypeWithMessage(message, expectedType, actualType, null);
     }
 
      /**
@@ -89,14 +69,13 @@ public class TypeMismatchException extends RuntimeException {
     public static TypeMismatchException forUnexpectedTypeWithCause(Class<?> expectedType,
                                                                    Class<?> actualType,
                                                                    ClassCastException cause) {
-        var message = f("Cannot cast value of type {} to type {}",
-                actualType.getName(), expectedType.getName());
-        return new TypeMismatchException(message, cause);
+        var message = f("Cannot cast value of type {} to type {}", actualType.getName(), expectedType.getName());
+        return TypeMismatchException.forUnexpectedTypeWithMessage(message, expectedType, actualType, cause);
     }
 
     /**
      * Factory method to create a new instance with a standardized message for a type mismatch
-     * on a collection element.
+     * on a collection element. The returned exception has no cause.
      * 
      * @param collectionType the type of collection, such as Collection, List, or Set
      * @param expectedType   the expected type of the collection elements
@@ -108,11 +87,12 @@ public class TypeMismatchException extends RuntimeException {
                                                                            Class<?> actualType) {
         var message = f("Expected {} to contain elements of type {}, but found element of type {}",
                 collectionType.getName(), expectedType.getName(), actualType.getName());
-        return new TypeMismatchException(message);
+        return TypeMismatchException.forUnexpectedTypeWithMessage(message, expectedType, actualType, null);
     }
 
     /**
      * Factory method to create a new instance with a standardized message for a map key type mismatch.
+     * The returned exception has no cause.
      * 
      * @param expectedKeyType the expected type of keys in the map
      * @param actualKeyType   the actual type of key found in the map
@@ -122,11 +102,12 @@ public class TypeMismatchException extends RuntimeException {
                                                                 Class<?> actualKeyType) {
         var message = f("Expected Map to contain keys of type {}, but found key of type {}",
                 expectedKeyType.getName(), actualKeyType.getName());
-        return new TypeMismatchException(message);
+        return TypeMismatchException.forUnexpectedTypeWithMessage(message, expectedKeyType, actualKeyType, null);
     }
 
     /**
      * Factory method to create a new instance with a standardized message for a map value type mismatch.
+     * The returned exception has no cause.
      * 
      * @param expectedValueType the expected type of values in the map
      * @param actualValueType   the actual type of value found in the map
@@ -136,6 +117,23 @@ public class TypeMismatchException extends RuntimeException {
                                                                   Class<?> actualValueType) {
         var message = f("Expected Map to contain values of type {}, but found value of type {}",
                 expectedValueType.getName(), actualValueType.getName());
-        return new TypeMismatchException(message);
+        return TypeMismatchException.forUnexpectedTypeWithMessage(message, expectedValueType, actualValueType, null);
+    }
+
+    /**
+     * Factory method to create a new instance of {@code TypeMismatchException} with a custom message,
+     * expected type, actual type, and an optional cause.
+     *
+     * @param message      a custom descriptive message explaining the type mismatch
+     * @param expectedType the expected type of the value
+     * @param actualType   the actual type of the value
+     * @param cause        the (optional) {@code ClassCastException} that occurred during the cast attempt
+     * @return a new instance of {@code TypeMismatchException} representing the type mismatch
+     */
+    public static TypeMismatchException forUnexpectedTypeWithMessage(String message,
+                                                                     Class<?> expectedType,
+                                                                     Class<?> actualType,
+                                                                     ClassCastException cause) {
+        return new TypeMismatchException(message, expectedType, actualType, cause);
     }
 }

--- a/src/test/java/org/kiwiproject/beta/base/KiwiCasts2Test.java
+++ b/src/test/java/org/kiwiproject/beta/base/KiwiCasts2Test.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -13,6 +14,7 @@ import org.kiwiproject.collect.KiwiLists;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 @DisplayName("KiwiCasts2")
 class KiwiCasts2Test {
@@ -158,38 +160,37 @@ class KiwiCasts2Test {
             @ParameterizedTest
             @NullAndEmptySource
             void shouldReturnList_WhenIsNullOrEmpty(List<?> coll) {
-                List<String> stringColl = KiwiCasts2.castToListAndCheckElements(String.class, coll);
-                assertThat(stringColl).isSameAs(coll);
+                List<String> stringList = KiwiCasts2.castToListAndCheckElements(String.class, coll);
+                assertThat(stringList).isSameAs(coll);
             }
 
             @Test
             void shouldReturnList_WhenAllElementsAreNull() {
                 Object o = Lists.newArrayList(null, null, null, null, null, null);
-                List<String> coll = KiwiCasts2.castToListAndCheckElements(String.class, o);
-                assertThat(coll).isSameAs(o);
+                List<String> list = KiwiCasts2.castToListAndCheckElements(String.class, o);
+                assertThat(list).isSameAs(o);
             }
 
             @Test
             void shouldReturnList_WhenExceedMaxNulls() {
                 Object o = Lists.newArrayList(null, null, null, null, null, null, "a", null, "b", "c", "d", null, null, null, "e", null, "f", "g");
-                List<String> coll = KiwiCasts2.castToListAndCheckElements(String.class, o);
-                assertThat(coll).isSameAs(o);
+                List<String> list = KiwiCasts2.castToListAndCheckElements(String.class, o);
+                assertThat(list).isSameAs(o);
             }
 
             @Test
             void shouldReturnList_WhenContainsExpectedType() {
                 Object o = Lists.newArrayList("a", "b", "c", "d", "e");
-                List<String> coll = KiwiCasts2.castToListAndCheckElements(String.class, o);
-                assertThat(coll).isSameAs(o);
+                List<String> list = KiwiCasts2.castToListAndCheckElements(String.class, o);
+                assertThat(list).isSameAs(o);
             }
 
             @Test
             void shouldReturnList_ThatThrowsClassCast_WhenExceedMaxNulls_ButDidNotDetectBadType() {
                 Object o = Lists.newArrayList(null, null, null, null, null, null, "a", null, "b", "c", "d", null, null, null, "e", null, "f", "g", 42);
-                List<String> coll = KiwiCasts2.castToListAndCheckElements(String.class, o);
+                List<String> list = KiwiCasts2.castToListAndCheckElements(String.class, o);
 
-                assertThat(coll).isSameAs(o);
-                var list = coll.stream().toList();
+                assertThat(list).isSameAs(o);
                 assertThatExceptionOfType(ClassCastException.class).isThrownBy(() -> {
                     // We must do the assignment to get the ClassCastException
                     @SuppressWarnings("unused") String last = KiwiLists.last(list);
@@ -212,6 +213,57 @@ class KiwiCasts2Test {
         @Nested
         class UsingDefaultSetCheckStrategy {
 
+            @ParameterizedTest
+            @NullAndEmptySource
+            void shouldReturnSet_WhenIsNullOrEmpty(Set<?> coll) {
+                Set<String> stringSet = KiwiCasts2.castToSetAndCheckElements(String.class, coll);
+                assertThat(stringSet).isSameAs(coll);
+            }
+
+            @Test
+            void shouldReturnSet_WhenAllElementsAreNull() {
+                Object o = Sets.newHashSet(null, null, null, null, null, null);
+                Set<String> set = KiwiCasts2.castToSetAndCheckElements(String.class, o);
+                assertThat(set).isSameAs(o);
+            }
+
+            @Test
+            void shouldReturnSet_WhenExceedMaxNulls() {
+                Object o = Sets.newHashSet(null, null, null, null, null, null, "a", null, "b", "c", "d", null, null, null, "e", null, "f", "g");
+                Set<String> coll = KiwiCasts2.castToSetAndCheckElements(String.class, o);
+                assertThat(coll).isSameAs(o);
+            }
+
+            @Test
+            void shouldReturnSet_WhenContainsExpectedType() {
+                Object o = Sets.newHashSet("a", "b", "c", "d", "e");
+                Set<String> coll = KiwiCasts2.castToSetAndCheckElements(String.class, o);
+                assertThat(coll).isSameAs(o);
+            }
+
+            @Test
+            void shouldReturnSet_ThatThrowsClassCast_WhenExceedMaxNulls_ButDidNotDetectBadType() {
+                // Note: LinkedHashSet is used here to preserve the order of elements
+                Object o = Sets.newLinkedHashSet(
+                        Lists.newArrayList(null, null, null, null, null, null, "a", null, "b", "c", "d", null, null, null, "e", null, "f", "g", 42)
+                );
+                Set<String> coll = KiwiCasts2.castToSetAndCheckElements(String.class, o);
+
+                assertThat(coll).isSameAs(o);
+                var list = coll.stream().toList();
+                assertThatExceptionOfType(ClassCastException.class).isThrownBy(() -> {
+                    // We must do the assignment to get the ClassCastException
+                    @SuppressWarnings("unused") String last = KiwiLists.last(list);
+                });
+            }
+
+            @Test
+            void shouldThrowTypeMismatchException_WhenFindBadType() {
+                Object o = Sets.newHashSet(null, null, null, null, null, null, 1, null, 2, 3, 4, 5, 6);
+                assertThatExceptionOfType(TypeMismatchException.class)
+                        .isThrownBy(() -> KiwiCasts2.castToSetAndCheckElements(String.class, o))
+                        .withMessage("Expected java.util.Set to contain elements of type java.lang.String, but found element of type java.lang.Integer");
+            }
         }
     }
 

--- a/src/test/java/org/kiwiproject/beta/base/KiwiCasts2Test.java
+++ b/src/test/java/org/kiwiproject/beta/base/KiwiCasts2Test.java
@@ -149,7 +149,7 @@ class KiwiCasts2Test {
                 var strategy = KiwiCasts2.StandardCollectionCheckStrategy.ofDefaults();
                 assertThatExceptionOfType(TypeMismatchException.class)
                         .isThrownBy(() -> KiwiCasts2.castToCollectionAndCheckElements(String.class, "not a collection", strategy))
-                        .withMessage("Cannot cast value to type java.util.Collection")
+                        .withMessage("Cannot cast value of type java.lang.String to type java.util.Collection")
                         .withCauseInstanceOf(ClassCastException.class);
             }
 
@@ -214,7 +214,7 @@ class KiwiCasts2Test {
             void shouldThrowTypeMismatchException_WhenIsNotCollection() {
                 assertThatExceptionOfType(TypeMismatchException.class)
                         .isThrownBy(() -> KiwiCasts2.castToListAndCheckElements(String.class, "not a collection"))
-                        .withMessage("Cannot cast value to type java.util.List")
+                        .withMessage("Cannot cast value of type java.lang.String to type java.util.List")
                         .withCauseInstanceOf(ClassCastException.class);
             }
 
@@ -296,7 +296,7 @@ class KiwiCasts2Test {
                 var strategy = KiwiCasts2.StandardListCheckStrategy.ofDefaults();
                 assertThatExceptionOfType(TypeMismatchException.class)
                         .isThrownBy(() -> KiwiCasts2.castToListAndCheckElements(String.class, "not a list", strategy))
-                        .withMessage("Cannot cast value to type java.util.List")
+                        .withMessage("Cannot cast value of type java.lang.String to type java.util.List")
                         .withCauseInstanceOf(ClassCastException.class);
             }
 
@@ -365,7 +365,7 @@ class KiwiCasts2Test {
             void shouldThrowTypeMismatchException_WhenIsNotSet() {
                 assertThatExceptionOfType(TypeMismatchException.class)
                         .isThrownBy(() -> KiwiCasts2.castToSetAndCheckElements(String.class, "not a collection"))
-                        .withMessage("Cannot cast value to type java.util.Set")
+                        .withMessage("Cannot cast value of type java.lang.String to type java.util.Set")
                         .withCauseInstanceOf(ClassCastException.class);
             }
 
@@ -452,7 +452,7 @@ class KiwiCasts2Test {
                 var strategy = KiwiCasts2.StandardSetCheckStrategy.ofDefaults();
                 assertThatExceptionOfType(TypeMismatchException.class)
                         .isThrownBy(() -> KiwiCasts2.castToSetAndCheckElements(String.class, "not a set", strategy))
-                        .withMessage("Cannot cast value to type java.util.Set")
+                        .withMessage("Cannot cast value of type java.lang.String to type java.util.Set")
                         .withCauseInstanceOf(ClassCastException.class);
             }
 
@@ -551,7 +551,7 @@ class KiwiCasts2Test {
             void shouldThrowTypeMismatchException_WhenIsNotMap() {
                 assertThatExceptionOfType(TypeMismatchException.class)
                         .isThrownBy(() -> KiwiCasts2.castToMapAndCheckEntries(String.class, Integer.class, "not a map"))
-                        .withMessage("Cannot cast value to type java.util.Map")
+                        .withMessage("Cannot cast value of type java.lang.String to type java.util.Map")
                         .withCauseInstanceOf(ClassCastException.class);
             }
 
@@ -724,7 +724,7 @@ class KiwiCasts2Test {
                 var strategy = KiwiCasts2.StandardMapCheckStrategy.ofDefaults();
                 assertThatExceptionOfType(TypeMismatchException.class)
                         .isThrownBy(() -> KiwiCasts2.castToMapAndCheckEntries(String.class, Integer.class, "not a map", strategy))
-                        .withMessage("Cannot cast value to type java.util.Map")
+                        .withMessage("Cannot cast value of type java.lang.String to type java.util.Map")
                         .withCauseInstanceOf(ClassCastException.class);
             }
 

--- a/src/test/java/org/kiwiproject/beta/base/KiwiCasts2Test.java
+++ b/src/test/java/org/kiwiproject/beta/base/KiwiCasts2Test.java
@@ -161,7 +161,7 @@ class KiwiCasts2Test {
     class CastToSetAndCheckElements {
 
         @Nested
-        class UsingDefaultListElementCheckingStrategy {
+        class UsingDefaultSetCheckStrategy {
 
         }
     }
@@ -170,7 +170,7 @@ class KiwiCasts2Test {
     class CastToMapAndCheckElements {
 
         @Nested
-        class UsingDefaultListElementCheckingStrategy {
+        class UsingDefaultMapCheckingStrategy {
 
         }
     }

--- a/src/test/java/org/kiwiproject/beta/base/KiwiCasts2Test.java
+++ b/src/test/java/org/kiwiproject/beta/base/KiwiCasts2Test.java
@@ -2,6 +2,7 @@ package org.kiwiproject.beta.base;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 import com.google.common.collect.Lists;
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.kiwiproject.collect.KiwiLists;
 import org.kiwiproject.collect.KiwiMaps;
@@ -29,9 +31,16 @@ class KiwiCasts2Test {
         @Nested
         class UsingDefaultCollectionCheckStrategy {
 
+            @Test
+            void shouldThrowIllegalArgument_WhenCollectionIsNull() {
+                assertThatIllegalArgumentException()
+                        .isThrownBy(() -> KiwiCasts2.castToCollectionAndCheckElements(String.class, null))
+                        .withMessage("object must not be null");
+            }
+
             @ParameterizedTest
-            @NullAndEmptySource
-            void shouldReturnCollection_WhenIsNullOrEmpty(Collection<?> coll) {
+            @EmptySource
+            void shouldReturnCollection_WhenIsEmpty(Collection<?> coll) {
                 Collection<String> stringColl = KiwiCasts2.castToCollectionAndCheckElements(String.class, coll);
                 assertThat(stringColl).isSameAs(coll);
             }
@@ -82,9 +91,17 @@ class KiwiCasts2Test {
         @Nested
         class UsingStandardCollectionCheckStrategy {
 
+            @Test
+            void shouldThrowIllegalArgument_WhenCollectionIsNull() {
+                var strategy = KiwiCasts2.StandardCollectionCheckStrategy.ofDefaults();
+                assertThatIllegalArgumentException()
+                        .isThrownBy(() -> KiwiCasts2.castToCollectionAndCheckElements(String.class, null, strategy))
+                        .withMessage("object must not be null");
+            }
+
             @ParameterizedTest
-            @NullAndEmptySource
-            void shouldReturnCollection_WhenIsNullOrEmpty(Collection<?> coll) {
+            @EmptySource
+            void shouldReturnCollection_WhenIsEmpty(Collection<?> coll) {
                 var strategy = KiwiCasts2.StandardCollectionCheckStrategy.ofDefaults();
                 Collection<String> stringColl = KiwiCasts2.castToCollectionAndCheckElements(String.class, coll, strategy);
                 assertThat(stringColl).isSameAs(coll);

--- a/src/test/java/org/kiwiproject/beta/base/KiwiCasts2Test.java
+++ b/src/test/java/org/kiwiproject/beta/base/KiwiCasts2Test.java
@@ -158,35 +158,35 @@ class KiwiCasts2Test {
             @ParameterizedTest
             @NullAndEmptySource
             void shouldReturnList_WhenIsNullOrEmpty(List<?> coll) {
-                Collection<String> stringColl = KiwiCasts2.castToListAndCheckElements(String.class, coll);
+                List<String> stringColl = KiwiCasts2.castToListAndCheckElements(String.class, coll);
                 assertThat(stringColl).isSameAs(coll);
             }
 
             @Test
             void shouldReturnList_WhenAllElementsAreNull() {
                 Object o = Lists.newArrayList(null, null, null, null, null, null);
-                Collection<String> coll = KiwiCasts2.castToListAndCheckElements(String.class, o);
+                List<String> coll = KiwiCasts2.castToListAndCheckElements(String.class, o);
                 assertThat(coll).isSameAs(o);
             }
 
             @Test
             void shouldReturnList_WhenExceedMaxNulls() {
                 Object o = Lists.newArrayList(null, null, null, null, null, null, "a", null, "b", "c", "d", null, null, null, "e", null, "f", "g");
-                Collection<String> coll = KiwiCasts2.castToListAndCheckElements(String.class, o);
+                List<String> coll = KiwiCasts2.castToListAndCheckElements(String.class, o);
                 assertThat(coll).isSameAs(o);
             }
 
             @Test
             void shouldReturnList_WhenContainsExpectedType() {
                 Object o = Lists.newArrayList("a", "b", "c", "d", "e");
-                Collection<String> coll = KiwiCasts2.castToListAndCheckElements(String.class, o);
+                List<String> coll = KiwiCasts2.castToListAndCheckElements(String.class, o);
                 assertThat(coll).isSameAs(o);
             }
 
             @Test
             void shouldReturnList_ThatThrowsClassCast_WhenExceedMaxNulls_ButDidNotDetectBadType() {
                 Object o = Lists.newArrayList(null, null, null, null, null, null, "a", null, "b", "c", "d", null, null, null, "e", null, "f", "g", 42);
-                Collection<String> coll = KiwiCasts2.castToListAndCheckElements(String.class, o);
+                List<String> coll = KiwiCasts2.castToListAndCheckElements(String.class, o);
 
                 assertThat(coll).isSameAs(o);
                 var list = coll.stream().toList();

--- a/src/test/java/org/kiwiproject/beta/base/KiwiCasts2Test.java
+++ b/src/test/java/org/kiwiproject/beta/base/KiwiCasts2Test.java
@@ -141,6 +141,14 @@ class KiwiCasts2Test {
             }
 
             @Test
+            void shouldThrowTypeMismatchException_WhenIsNotCollection() {
+                assertThatExceptionOfType(TypeMismatchException.class)
+                        .isThrownBy(() -> KiwiCasts2.castToCollectionAndCheckElements(String.class, "not a collection"))
+                        .withMessage("Cannot cast value to type java.util.Collection")
+                        .withCauseInstanceOf(ClassCastException.class);
+            }
+
+            @Test
             void shouldThrowTypeMismatchException_WhenFindBadType() {
                 Object o = Lists.newArrayList(null, null, 1, null, 2, 3, 4, 5, 6);
                 var strategy = KiwiCasts2.StandardCollectionCheckStrategy.ofDefaults();
@@ -195,6 +203,14 @@ class KiwiCasts2Test {
                     // We must do the assignment to get the ClassCastException
                     @SuppressWarnings("unused") String last = KiwiLists.last(list);
                 });
+            }
+
+            @Test
+            void shouldThrowTypeMismatchException_WhenIsNotCollection() {
+                assertThatExceptionOfType(TypeMismatchException.class)
+                        .isThrownBy(() -> KiwiCasts2.castToListAndCheckElements(String.class, "not a collection"))
+                        .withMessage("Cannot cast value to type java.util.List")
+                        .withCauseInstanceOf(ClassCastException.class);
             }
 
             @Test
@@ -255,6 +271,14 @@ class KiwiCasts2Test {
                     // We must do the assignment to get the ClassCastException
                     @SuppressWarnings("unused") String last = KiwiLists.last(list);
                 });
+            }
+
+            @Test
+            void shouldThrowTypeMismatchException_WhenIsNotSet() {
+                assertThatExceptionOfType(TypeMismatchException.class)
+                        .isThrownBy(() -> KiwiCasts2.castToSetAndCheckElements(String.class, "not a collection"))
+                        .withMessage("Cannot cast value to type java.util.Set")
+                        .withCauseInstanceOf(ClassCastException.class);
             }
 
             @Test

--- a/src/test/java/org/kiwiproject/beta/base/KiwiCasts2Test.java
+++ b/src/test/java/org/kiwiproject/beta/base/KiwiCasts2Test.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EmptySource;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.kiwiproject.collect.KiwiLists;
 import org.kiwiproject.collect.KiwiMaps;
 import org.kiwiproject.test.junit.jupiter.ClearBoxTest;
@@ -187,9 +186,16 @@ class KiwiCasts2Test {
         @Nested
         class UsingDefaultListCheckStrategy {
 
+            @Test
+            void shouldThrowIllegalArgument_WhenListIsNull() {
+                assertThatIllegalArgumentException()
+                        .isThrownBy(() -> KiwiCasts2.castToListAndCheckElements(String.class, null))
+                        .withMessage("object must not be null");
+            }
+
             @ParameterizedTest
-            @NullAndEmptySource
-            void shouldReturnList_WhenIsNullOrEmpty(List<?> coll) {
+            @EmptySource
+            void shouldReturnList_WhenIsEmpty(List<?> coll) {
                 List<String> stringList = KiwiCasts2.castToListAndCheckElements(String.class, coll);
                 assertThat(stringList).isSameAs(coll);
             }
@@ -247,9 +253,17 @@ class KiwiCasts2Test {
         @Nested
         class UsingStandardListCheckStrategy {
 
+            @Test
+            void shouldThrowIllegalArgument_WhenListIsNull() {
+                var strategy = KiwiCasts2.StandardListCheckStrategy.ofDefaults();
+                assertThatIllegalArgumentException()
+                        .isThrownBy(() -> KiwiCasts2.castToListAndCheckElements(String.class, null, strategy))
+                        .withMessage("object must not be null");
+            }
+
             @ParameterizedTest
-            @NullAndEmptySource
-            void shouldReturnList_WhenIsNullOrEmpty(List<?> coll) {
+            @EmptySource
+            void shouldReturnList_WhenIsEmpty(List<?> coll) {
                 var strategy = KiwiCasts2.StandardListCheckStrategy.ofDefaults();
                 List<String> stringList = KiwiCasts2.castToListAndCheckElements(String.class, coll, strategy);
                 assertThat(stringList).isSameAs(coll);
@@ -334,9 +348,16 @@ class KiwiCasts2Test {
         @Nested
         class UsingDefaultSetCheckStrategy {
 
+            @Test
+            void shouldThrowIllegalArgument_WhenSetIsNull() {
+                assertThatIllegalArgumentException()
+                        .isThrownBy(() -> KiwiCasts2.castToSetAndCheckElements(String.class, null))
+                        .withMessage("object must not be null");
+            }
+
             @ParameterizedTest
-            @NullAndEmptySource
-            void shouldReturnSet_WhenIsNullOrEmpty(Set<?> coll) {
+            @EmptySource
+            void shouldReturnSet_WhenIsEmpty(Set<?> coll) {
                 Set<String> stringSet = KiwiCasts2.castToSetAndCheckElements(String.class, coll);
                 assertThat(stringSet).isSameAs(coll);
             }
@@ -398,9 +419,17 @@ class KiwiCasts2Test {
         @Nested
         class UsingStandardSetCheckStrategy {
 
+            @Test
+            void shouldThrowIllegalArgument_WhenSetIsNull() {
+                var strategy = KiwiCasts2.StandardSetCheckStrategy.ofDefaults();
+                assertThatIllegalArgumentException()
+                        .isThrownBy(() -> KiwiCasts2.castToSetAndCheckElements(String.class, null, strategy))
+                        .withMessage("object must not be null");
+            }
+
             @ParameterizedTest
-            @NullAndEmptySource
-            void shouldReturnList_WhenIsNullOrEmpty(Set<?> set) {
+            @EmptySource
+            void shouldReturnSet_WhenIsEmpty(Set<?> set) {
                 var strategy = KiwiCasts2.StandardSetCheckStrategy.ofDefaults();
                 Set<String> stringSet = KiwiCasts2.castToSetAndCheckElements(String.class, set, strategy);
                 assertThat(stringSet).isSameAs(set);
@@ -490,9 +519,16 @@ class KiwiCasts2Test {
         @Nested
         class UsingDefaultMapCheckStrategy {
 
+            @Test
+            void shouldThrowIllegalArgument_WhenMapIsNull() {
+                assertThatIllegalArgumentException()
+                        .isThrownBy(() -> KiwiCasts2.castToMapAndCheckEntries(String.class, Integer.class, null))
+                        .withMessage("object must not be null");
+            }
+
             @ParameterizedTest
-            @NullAndEmptySource
-            void shouldReturnMap_WhenIsNullOrEmpty(Map<?, ?> map) {
+            @EmptySource
+            void shouldReturnMap_WhenIsEmpty(Map<?, ?> map) {
                 Map<String, Integer> stringIntegerMap = KiwiCasts2.castToMapAndCheckEntries(String.class, Integer.class, map);
                 assertThat(stringIntegerMap).isSameAs(map);
             }
@@ -614,9 +650,17 @@ class KiwiCasts2Test {
                         .withMessage("EntryCheckResult has unexpected entryType: KEY");
             }
 
+            @Test
+            void shouldThrowIllegalArgument_WhenMapIsNull() {
+                var strategy = KiwiCasts2.StandardMapCheckStrategy.ofDefaults();
+                assertThatIllegalArgumentException()
+                        .isThrownBy(() -> KiwiCasts2.castToMapAndCheckEntries(String.class, Integer.class, null, strategy))
+                        .withMessage("object must not be null");
+            }
+
             @ParameterizedTest
-            @NullAndEmptySource
-            void shouldReturnMap_WhenIsNullOrEmpty(Map<?, ?> map) {
+            @EmptySource
+            void shouldReturnMap_WhenIsEmpty(Map<?, ?> map) {
                 var strategy = KiwiCasts2.StandardMapCheckStrategy.ofDefaults();
                 Map<String, Integer> stringIntegerMap =
                         KiwiCasts2.castToMapAndCheckEntries(String.class, Integer.class, map, strategy);

--- a/src/test/java/org/kiwiproject/beta/base/KiwiCasts2Test.java
+++ b/src/test/java/org/kiwiproject/beta/base/KiwiCasts2Test.java
@@ -523,7 +523,7 @@ class KiwiCasts2Test {
             }
 
             @Test
-            void shouldReturnMap_ThatThrowsClassCast_WhenExceedsMaxNulls_ButDidNotDetecBadType() {
+            void shouldReturnMap_ThatThrowsClassCast_WhenExceedsMaxNulls_ButDidNotDetectBadType() {
                 Object o = KiwiMaps.newLinkedHashMap(
                         "a", null,
                         "b", null,

--- a/src/test/java/org/kiwiproject/beta/base/KiwiCasts2Test.java
+++ b/src/test/java/org/kiwiproject/beta/base/KiwiCasts2Test.java
@@ -571,11 +571,11 @@ class KiwiCasts2Test {
             @Test
             void shouldThrowTypeMismatchException_WhenFindBadValueType() {
                 Object o = KiwiMaps.newLinkedHashMap(
-                        "a", null,
-                        "b", "one",
-                        "c", "two",
-                        "d", "three",
-                        "e", "four"
+                        "a", "one",
+                        "b", "two",
+                        "c", "three",
+                        "d", "four",
+                        "e", "five"
                 );
 
                 assertThatExceptionOfType(TypeMismatchException.class)

--- a/src/test/java/org/kiwiproject/beta/base/KiwiCasts2Test.java
+++ b/src/test/java/org/kiwiproject/beta/base/KiwiCasts2Test.java
@@ -675,7 +675,7 @@ class KiwiCasts2Test {
             }
 
             @Test
-            void shouldReturnMap_WhenEntriesContainExpectedTypes_AndFewerElementsThanMaxTypeChecks() {
+            void shouldReturnMap_WhenEntriesContainExpectedTypes_AndFewerEntriesThanMaxTypeChecks() {
                 Object o = KiwiMaps.newLinkedHashMap("a", 1, "b", 2, "c", 3, "d", 4);
                 var strategy = KiwiCasts2.StandardMapCheckStrategy.of(0, 5);
                 Map<String, Integer> map = KiwiCasts2.castToMapAndCheckEntries(String.class, Integer.class, o, strategy);
@@ -683,7 +683,7 @@ class KiwiCasts2Test {
             }
 
             @Test
-            void shouldReturnMap_WhenEntriesContainExpectedTypes_AndMoreElementsThanMaxTypeChecks() {
+            void shouldReturnMap_WhenEntriesContainExpectedTypes_AndMoreEntriesThanMaxTypeChecks() {
                 Object o = KiwiMaps.newLinkedHashMap("a", 1, "b", 2, "c", 3, "d", 4);
                 var strategy = KiwiCasts2.StandardMapCheckStrategy.of(0, 3);
                 Map<String, Integer> map = KiwiCasts2.castToMapAndCheckEntries(String.class, Integer.class, o, strategy);

--- a/src/test/java/org/kiwiproject/beta/base/KiwiCasts2Test.java
+++ b/src/test/java/org/kiwiproject/beta/base/KiwiCasts2Test.java
@@ -1,0 +1,165 @@
+package org.kiwiproject.beta.base;
+
+import com.google.common.collect.Lists;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junitpioneer.jupiter.ExpectedToFail;
+
+import java.util.Collection;
+
+@DisplayName("KiwiCasts2")
+class KiwiCasts2Test {
+
+    // TODO
+
+    @Nested
+    class CastToCollectionAndCheckElements {
+
+        @Nested
+        class UsingDefaultCollectionCheckStrategy {
+
+            @ParameterizedTest
+            @NullAndEmptySource
+            void testTEMP_giveUpNullAndEmpty(Collection<String> coll) {
+                Object o = coll;
+                Collection<String> stringColl = KiwiCasts2.castToCollectionAndCheckElements(String.class, o);
+                System.out.println("coll = " + stringColl);
+            }
+
+            @Test
+            void testTEMP_giveUpAllNull() {
+                Object o = Lists.newArrayList(null, null, null, null, null, null);
+                Collection<String> coll = KiwiCasts2.castToCollectionAndCheckElements(String.class, o);
+                System.out.println("coll = " + coll);
+            }
+
+            @Test
+            void testTEMP_giveUpTooManyNulls() {
+                Object o = Lists.newArrayList(null, null, null, null, null, null, "a", null, "b", "c", "d", null, null, null, "e", null, "f", "g");
+                Collection<String> coll = KiwiCasts2.castToCollectionAndCheckElements(String.class, o);
+                System.out.println("coll = " + coll);
+            }
+
+            @Test
+            @ExpectedToFail(withExceptions = ClassCastException.class)
+            void testTEMP_giveUpTooManyNulls_ButDidNotDetectBadType() {
+                Object o = Lists.newArrayList(null, null, null, null, null, null, "a", null, "b", "c", "d", null, null, null, "e", null, "f", "g", 42);
+                Collection<String> coll = KiwiCasts2.castToCollectionAndCheckElements(String.class, o);
+                System.out.println("coll = " + coll);
+
+                coll.forEach(str -> {
+                    if (str != null) {
+                        System.out.println(str + " has length " + str.length());
+                    }
+                });
+            }
+
+            @Test
+            @ExpectedToFail(withExceptions = TypeMismatchException.class)
+            void testTEMP_findBadType() {
+                Object o = Lists.newArrayList(null, null, null, null, null, null, 1, null, 2, 3, 4, 5, 6);
+                Collection<String> coll = KiwiCasts2.castToCollectionAndCheckElements(String.class, o);
+                System.out.println("coll = " + coll);
+            }
+
+            @Test
+            void testTEMP_ok() {
+                Object o = Lists.newArrayList("a", "b", "c", "d", "e");
+                Collection<String> coll = KiwiCasts2.castToCollectionAndCheckElements(String.class, o);
+                System.out.println("coll = " + coll);
+            }
+        }
+
+        @Nested
+        class UsingStandardCollectionCheckStrategy {
+
+            @ParameterizedTest
+            @NullAndEmptySource
+            void testTEMP_giveUpNullAndEmpty(Collection<String> coll) {
+                Object o = coll;
+                Collection<String> stringColl = KiwiCasts2.castToCollectionAndCheckElements(String.class, o, KiwiCasts2.StandardCollectionCheckStrategy.ofDefaults());
+                System.out.println("coll = " + stringColl);
+            }
+
+            @Test
+            void testTEMP_giveUpAllNull() {
+                Object o = Lists.newArrayList(null, null, null, null, null, null);
+                Collection<String> coll = KiwiCasts2.castToCollectionAndCheckElements(String.class, o, KiwiCasts2.StandardCollectionCheckStrategy.ofDefaults());
+                System.out.println("coll = " + coll);
+            }
+
+            @Test
+            void testTEMP_giveUpTooManyNulls() {
+                Object o = Lists.newArrayList(null, null, null, null, null, null, "a", null, "b", "c", "d", null, null, null, "e", null, "f", "g");
+                Collection<String> coll = KiwiCasts2.castToCollectionAndCheckElements(String.class, o, KiwiCasts2.StandardCollectionCheckStrategy.ofDefaults());
+                System.out.println("coll = " + coll);
+            }
+
+            @Test
+            @ExpectedToFail(withExceptions = ClassCastException.class)
+            void testTEMP_giveUpTooManyNulls_ButDidNotDetectBadType() {
+                Object o = Lists.newArrayList(null, null, null, null, null, null, "a", null, "b", "c", "d", null, null, null, "e", null, "f", "g", 42);
+                Collection<String> coll = KiwiCasts2.castToCollectionAndCheckElements(String.class, o, KiwiCasts2.StandardCollectionCheckStrategy.ofDefaults());
+                System.out.println("coll = " + coll);
+
+                coll.forEach(str -> {
+                    if (str != null) {
+                        System.out.println(str + " has length " + str.length());
+                    }
+                });
+            }
+
+            @Test
+            @ExpectedToFail(withExceptions = TypeMismatchException.class)
+            void testTEMP_findBadType() {
+                Object o = Lists.newArrayList(null, null, null, null, null, null, "a", null, "b", "c", "d", 42, "e");
+                Collection<String> coll = KiwiCasts2.castToCollectionAndCheckElements(String.class, o, KiwiCasts2.StandardCollectionCheckStrategy.ofDefaults());
+                System.out.println("coll = " + coll);
+            }
+
+            @Test
+            void testTEMP_ok_fewerElementsThanMaxTypeChecks() {
+                Object o = Lists.newArrayList("a", "b", "c", "d", "e");
+                Collection<String> coll = KiwiCasts2.castToCollectionAndCheckElements(String.class, o, KiwiCasts2.StandardCollectionCheckStrategy.ofDefaults());
+                System.out.println("coll = " + coll);
+            }
+
+            @Test
+            void testTEMP_ok_moreElementsThanMaxTypeChecks() {
+                Object o = Lists.newArrayList("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z");
+                Collection<String> coll = KiwiCasts2.castToCollectionAndCheckElements(String.class, o, KiwiCasts2.StandardCollectionCheckStrategy.ofDefaults());
+                System.out.println("coll = " + coll);
+            }
+        }
+    }
+
+    @Nested
+    class CastToListAndCheckElements {
+
+        @Nested
+        class UsingDefaultListCheckStrategy {
+
+        }
+    }
+
+    @Nested
+    class CastToSetAndCheckElements {
+
+        @Nested
+        class UsingDefaultListElementCheckingStrategy {
+
+        }
+    }
+
+    @Nested
+    class CastToMapAndCheckElements {
+
+        @Nested
+        class UsingDefaultListElementCheckingStrategy {
+
+        }
+    }
+}

--- a/src/test/java/org/kiwiproject/beta/base/KiwiCasts2Test.java
+++ b/src/test/java/org/kiwiproject/beta/base/KiwiCasts2Test.java
@@ -1,19 +1,20 @@
 package org.kiwiproject.beta.base;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 import com.google.common.collect.Lists;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
-import org.junitpioneer.jupiter.ExpectedToFail;
+import org.kiwiproject.collect.KiwiLists;
 
 import java.util.Collection;
 
 @DisplayName("KiwiCasts2")
 class KiwiCasts2Test {
-
-    // TODO
 
     @Nested
     class CastToCollectionAndCheckElements {
@@ -23,53 +24,51 @@ class KiwiCasts2Test {
 
             @ParameterizedTest
             @NullAndEmptySource
-            void testTEMP_giveUpNullAndEmpty(Collection<String> coll) {
-                Object o = coll;
-                Collection<String> stringColl = KiwiCasts2.castToCollectionAndCheckElements(String.class, o);
-                System.out.println("coll = " + stringColl);
+            void shouldReturnCollection_WhenIsNullOrEmpty(Collection<?> coll) {
+                Collection<String> stringColl = KiwiCasts2.castToCollectionAndCheckElements(String.class, coll);
+                assertThat(stringColl).isSameAs(coll);
             }
 
             @Test
-            void testTEMP_giveUpAllNull() {
+            void shouldReturnCollection_WhenAllElementsAreNull() {
                 Object o = Lists.newArrayList(null, null, null, null, null, null);
                 Collection<String> coll = KiwiCasts2.castToCollectionAndCheckElements(String.class, o);
-                System.out.println("coll = " + coll);
+                assertThat(coll).isSameAs(o);
             }
 
             @Test
-            void testTEMP_giveUpTooManyNulls() {
+            void shouldReturnCollection_WhenExceedMaxNulls() {
                 Object o = Lists.newArrayList(null, null, null, null, null, null, "a", null, "b", "c", "d", null, null, null, "e", null, "f", "g");
                 Collection<String> coll = KiwiCasts2.castToCollectionAndCheckElements(String.class, o);
-                System.out.println("coll = " + coll);
+                assertThat(coll).isSameAs(o);
             }
 
             @Test
-            @ExpectedToFail(withExceptions = ClassCastException.class)
-            void testTEMP_giveUpTooManyNulls_ButDidNotDetectBadType() {
+            void shouldReturnCollection_WhenContainsExpectedType() {
+                Object o = Lists.newArrayList("a", "b", "c", "d", "e");
+                Collection<String> coll = KiwiCasts2.castToCollectionAndCheckElements(String.class, o);
+                assertThat(coll).isSameAs(o);
+            }
+
+            @Test
+            void shouldReturnCollection_ThatThrowsClassCast_WhenExceedMaxNulls_ButDidNotDetectBadType() {
                 Object o = Lists.newArrayList(null, null, null, null, null, null, "a", null, "b", "c", "d", null, null, null, "e", null, "f", "g", 42);
                 Collection<String> coll = KiwiCasts2.castToCollectionAndCheckElements(String.class, o);
-                System.out.println("coll = " + coll);
 
-                coll.forEach(str -> {
-                    if (str != null) {
-                        System.out.println(str + " has length " + str.length());
-                    }
+                assertThat(coll).isSameAs(o);
+                var list = coll.stream().toList();
+                assertThatExceptionOfType(ClassCastException.class).isThrownBy(() -> {
+                    // We must do the assignment to get the ClassCastException
+                    @SuppressWarnings("unused") String last = KiwiLists.last(list);
                 });
             }
 
             @Test
-            @ExpectedToFail(withExceptions = TypeMismatchException.class)
-            void testTEMP_findBadType() {
+            void shouldThrowTypeMismatchException_WhenFindBadType() {
                 Object o = Lists.newArrayList(null, null, null, null, null, null, 1, null, 2, 3, 4, 5, 6);
-                Collection<String> coll = KiwiCasts2.castToCollectionAndCheckElements(String.class, o);
-                System.out.println("coll = " + coll);
-            }
-
-            @Test
-            void testTEMP_ok() {
-                Object o = Lists.newArrayList("a", "b", "c", "d", "e");
-                Collection<String> coll = KiwiCasts2.castToCollectionAndCheckElements(String.class, o);
-                System.out.println("coll = " + coll);
+                assertThatExceptionOfType(TypeMismatchException.class)
+                        .isThrownBy(() -> KiwiCasts2.castToCollectionAndCheckElements(String.class, o))
+                        .withMessage("Expected java.util.Collection to contain elements of type java.lang.String, but found element of type java.lang.Integer");
             }
         }
 
@@ -78,60 +77,73 @@ class KiwiCasts2Test {
 
             @ParameterizedTest
             @NullAndEmptySource
-            void testTEMP_giveUpNullAndEmpty(Collection<String> coll) {
-                Object o = coll;
-                Collection<String> stringColl = KiwiCasts2.castToCollectionAndCheckElements(String.class, o, KiwiCasts2.StandardCollectionCheckStrategy.ofDefaults());
-                System.out.println("coll = " + stringColl);
+            void shouldReturnCollection_WhenIsNullOrEmpty(Collection<?> coll) {
+                var strategy = KiwiCasts2.StandardCollectionCheckStrategy.ofDefaults();
+                Collection<String> stringColl = KiwiCasts2.castToCollectionAndCheckElements(String.class, coll, strategy);
+                assertThat(stringColl).isSameAs(coll);
             }
 
             @Test
-            void testTEMP_giveUpAllNull() {
+            void shouldReturnCollection_WhenAllElementsAreNull() {
                 Object o = Lists.newArrayList(null, null, null, null, null, null);
-                Collection<String> coll = KiwiCasts2.castToCollectionAndCheckElements(String.class, o, KiwiCasts2.StandardCollectionCheckStrategy.ofDefaults());
-                System.out.println("coll = " + coll);
+                var strategy = KiwiCasts2.StandardCollectionCheckStrategy.ofDefaults();
+                Collection<String> coll = KiwiCasts2.castToCollectionAndCheckElements(String.class, o, strategy);
+                assertThat(coll).isSameAs(o);
             }
 
             @Test
-            void testTEMP_giveUpTooManyNulls() {
+            void shouldReturnCollection_WhenExceedMaxNulls() {
                 Object o = Lists.newArrayList(null, null, null, null, null, null, "a", null, "b", "c", "d", null, null, null, "e", null, "f", "g");
-                Collection<String> coll = KiwiCasts2.castToCollectionAndCheckElements(String.class, o, KiwiCasts2.StandardCollectionCheckStrategy.ofDefaults());
-                System.out.println("coll = " + coll);
+                var strategy = KiwiCasts2.StandardCollectionCheckStrategy.ofDefaults();
+                Collection<String> coll = KiwiCasts2.castToCollectionAndCheckElements(String.class, o, strategy);
+                assertThat(coll).isSameAs(o);
             }
 
             @Test
-            @ExpectedToFail(withExceptions = ClassCastException.class)
-            void testTEMP_giveUpTooManyNulls_ButDidNotDetectBadType() {
-                Object o = Lists.newArrayList(null, null, null, null, null, null, "a", null, "b", "c", "d", null, null, null, "e", null, "f", "g", 42);
-                Collection<String> coll = KiwiCasts2.castToCollectionAndCheckElements(String.class, o, KiwiCasts2.StandardCollectionCheckStrategy.ofDefaults());
-                System.out.println("coll = " + coll);
+            void shouldReturnCollection_WhenContainsExpectedType() {
+                Object o = Lists.newArrayList("a", "b", "c", "d", "e");
+                var strategy = KiwiCasts2.StandardCollectionCheckStrategy.ofDefaults();
+                Collection<String> coll = KiwiCasts2.castToCollectionAndCheckElements(String.class, o, strategy);
+                assertThat(coll).isSameAs(o);
+            }
 
-                coll.forEach(str -> {
-                    if (str != null) {
-                        System.out.println(str + " has length " + str.length());
-                    }
+            @Test
+            void shouldReturnCollection_WhenFewerElementsThanMaxTypeChecks() {
+                Object o = Lists.newArrayList("a", "b", "c");
+                var strategy = KiwiCasts2.StandardCollectionCheckStrategy.of(5, 20);
+                Collection<String> coll = KiwiCasts2.castToCollectionAndCheckElements(String.class, o, strategy);
+                assertThat(coll).isSameAs(o);
+            }
+
+            @Test
+            void shouldReturnCollection_WhenMoreElementsThanMaxTypeChecks() {
+                Object o = Lists.newArrayList("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z");
+                var strategy = KiwiCasts2.StandardCollectionCheckStrategy.of(5, 15);
+                Collection<String> coll = KiwiCasts2.castToCollectionAndCheckElements(String.class, o, strategy);
+                assertThat(coll).isSameAs(o);
+            }
+
+            @Test
+            void shouldReturnCollection_ThatThrowsClassCast_WhenExceedMaxNulls_ButDidNotDetectBadType() {
+                Object o = Lists.newArrayList(null, null, null, null, null, null, "a", null, "b", "c", "d", 42);
+                var strategy = KiwiCasts2.StandardCollectionCheckStrategy.of(3, 5);
+                Collection<String> coll = KiwiCasts2.castToCollectionAndCheckElements(String.class, o, strategy);
+
+                assertThat(coll).isSameAs(o);
+                var list = coll.stream().toList();
+                assertThatExceptionOfType(ClassCastException.class).isThrownBy(() -> {
+                    // We must do the assignment to get the ClassCastException
+                    @SuppressWarnings("unused") String last = KiwiLists.last(list);
                 });
             }
 
             @Test
-            @ExpectedToFail(withExceptions = TypeMismatchException.class)
-            void testTEMP_findBadType() {
-                Object o = Lists.newArrayList(null, null, null, null, null, null, "a", null, "b", "c", "d", 42, "e");
-                Collection<String> coll = KiwiCasts2.castToCollectionAndCheckElements(String.class, o, KiwiCasts2.StandardCollectionCheckStrategy.ofDefaults());
-                System.out.println("coll = " + coll);
-            }
-
-            @Test
-            void testTEMP_ok_fewerElementsThanMaxTypeChecks() {
-                Object o = Lists.newArrayList("a", "b", "c", "d", "e");
-                Collection<String> coll = KiwiCasts2.castToCollectionAndCheckElements(String.class, o, KiwiCasts2.StandardCollectionCheckStrategy.ofDefaults());
-                System.out.println("coll = " + coll);
-            }
-
-            @Test
-            void testTEMP_ok_moreElementsThanMaxTypeChecks() {
-                Object o = Lists.newArrayList("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z");
-                Collection<String> coll = KiwiCasts2.castToCollectionAndCheckElements(String.class, o, KiwiCasts2.StandardCollectionCheckStrategy.ofDefaults());
-                System.out.println("coll = " + coll);
+            void shouldThrowTypeMismatchException_WhenFindBadType() {
+                Object o = Lists.newArrayList(null, null, 1, null, 2, 3, 4, 5, 6);
+                var strategy = KiwiCasts2.StandardCollectionCheckStrategy.ofDefaults();
+                assertThatExceptionOfType(TypeMismatchException.class)
+                        .isThrownBy(() -> KiwiCasts2.castToCollectionAndCheckElements(String.class, o, strategy))
+                        .withMessage("Expected java.util.Collection to contain elements of type java.lang.String, but found element of type java.lang.Integer");
             }
         }
     }

--- a/src/test/java/org/kiwiproject/beta/base/TypeMismatchExceptionTest.java
+++ b/src/test/java/org/kiwiproject/beta/base/TypeMismatchExceptionTest.java
@@ -1,16 +1,82 @@
 package org.kiwiproject.beta.base;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.kiwiproject.test.junit.jupiter.StandardExceptionTests.standardConstructorTestsFor;
 
 import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 
 import java.util.Collection;
+import java.util.Set;
 
 class TypeMismatchExceptionTest {
 
     @TestFactory
     Collection<DynamicTest> shouldHaveStandardConstructors() {
         return standardConstructorTestsFor(TypeMismatchException.class);
+    }
+
+    @Test
+    void shouldCreate_forTypeMismatch_AndClassCastExceptionAsCause() {
+        var cause = new ClassCastException();
+        var ex = TypeMismatchException.forTypeMismatch(Double.class, cause);
+
+        assertAll(
+            () -> assertThat(ex).hasMessage("Cannot cast value to type java.lang.Double"),
+            () -> assertThat(ex).hasCause(cause)
+        );
+    }
+
+    @Test
+    void shouldCreate_forTypeMismatch_WithValueType_AndUnexpectedType() {
+        var ex = TypeMismatchException.forTypeMismatch(Double.class, Integer.class);
+
+         assertAll(
+            () -> assertThat(ex).hasMessage("Cannot cast value of type java.lang.Integer to type java.lang.Double"),
+            () -> assertThat(ex).hasNoCause()
+        );
+    }
+
+    @Test
+    void shouldCreate_forTypeMismatch_WithValueType_AndUnexpectedTypeh_AndClassCastExceptionAsCause() {
+        var cause = new ClassCastException();
+        var ex = TypeMismatchException.forTypeMismatch(Double.class, Integer.class, cause);
+
+         assertAll(
+            () -> assertThat(ex).hasMessage("Cannot cast value of type java.lang.Integer to type java.lang.Double"),
+            () -> assertThat(ex).hasCause(cause)
+        );
+    }
+
+    @Test
+    void shouldCreate_forCollectionTypeMismatch() {
+        var ex = TypeMismatchException.forCollectionTypeMismatch(Set.class, Integer.class, Double.class);
+
+        assertAll(
+            () -> assertThat(ex).hasMessage("Expected java.util.Set to contain elements of type java.lang.Integer, but found element of type java.lang.Double"),
+            () -> assertThat(ex).hasNoCause()
+        );
+    }
+
+    @Test
+    void shouldCreate_forMapKeyTypeMismatch() {
+        var ex = TypeMismatchException.forMapKeyTypeMismatch(String.class, Integer.class);
+
+        assertAll(
+            () -> assertThat(ex).hasMessage("Expected Map to contain keys of type java.lang.String, but found key of type java.lang.Integer"),
+            () -> assertThat(ex).hasNoCause()
+        );
+    }
+
+    @Test
+    void shouldCreate_forMapValueTypeMismatch() {
+        var ex = TypeMismatchException.forMapValueTypeMismatch(Integer.class, Long.class);
+
+        assertAll(
+            () -> assertThat(ex).hasMessage("Expected Map to contain values of type java.lang.Integer, but found value of type java.lang.Long"),
+            () -> assertThat(ex).hasNoCause()
+        );
     }
 }

--- a/src/test/java/org/kiwiproject/beta/base/TypeMismatchExceptionTest.java
+++ b/src/test/java/org/kiwiproject/beta/base/TypeMismatchExceptionTest.java
@@ -1,0 +1,16 @@
+package org.kiwiproject.beta.base;
+
+import static org.kiwiproject.test.junit.jupiter.StandardExceptionTests.standardConstructorTestsFor;
+
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+
+import java.util.Collection;
+
+class TypeMismatchExceptionTest {
+
+    @TestFactory
+    Collection<DynamicTest> shouldHaveStandardConstructors() {
+        return standardConstructorTestsFor(TypeMismatchException.class);
+    }
+}

--- a/src/test/java/org/kiwiproject/beta/base/TypeMismatchExceptionTest.java
+++ b/src/test/java/org/kiwiproject/beta/base/TypeMismatchExceptionTest.java
@@ -19,9 +19,9 @@ class TypeMismatchExceptionTest {
     }
 
     @Test
-    void shouldCreate_forTypeMismatch_AndClassCastExceptionAsCause() {
+    void shouldCreate_forExpectedTypeWithCause() {
         var cause = new ClassCastException();
-        var ex = TypeMismatchException.forTypeMismatch(Double.class, cause);
+        var ex = TypeMismatchException.forExpectedTypeWithCause(Double.class, cause);
 
         assertAll(
             () -> assertThat(ex).hasMessage("Cannot cast value to type java.lang.Double"),
@@ -31,7 +31,7 @@ class TypeMismatchExceptionTest {
 
     @Test
     void shouldCreate_forTypeMismatch_WithValueType_AndUnexpectedType() {
-        var ex = TypeMismatchException.forTypeMismatch(Double.class, Integer.class);
+        var ex = TypeMismatchException.forUnexpectedType(Double.class, Integer.class);
 
          assertAll(
             () -> assertThat(ex).hasMessage("Cannot cast value of type java.lang.Integer to type java.lang.Double"),
@@ -42,7 +42,7 @@ class TypeMismatchExceptionTest {
     @Test
     void shouldCreate_forTypeMismatch_WithValueType_AndUnexpectedTypeh_AndClassCastExceptionAsCause() {
         var cause = new ClassCastException();
-        var ex = TypeMismatchException.forTypeMismatch(Double.class, Integer.class, cause);
+        var ex = TypeMismatchException.forUnexpectedTypeWithCause(Double.class, Integer.class, cause);
 
          assertAll(
             () -> assertThat(ex).hasMessage("Cannot cast value of type java.lang.Integer to type java.lang.Double"),
@@ -51,8 +51,8 @@ class TypeMismatchExceptionTest {
     }
 
     @Test
-    void shouldCreate_forCollectionTypeMismatch() {
-        var ex = TypeMismatchException.forCollectionTypeMismatch(Set.class, Integer.class, Double.class);
+    void shouldCreate_forUnexpectedCollectionElementType() {
+        var ex = TypeMismatchException.forUnexpectedCollectionElementType(Set.class, Integer.class, Double.class);
 
         assertAll(
             () -> assertThat(ex).hasMessage("Expected java.util.Set to contain elements of type java.lang.Integer, but found element of type java.lang.Double"),
@@ -61,8 +61,8 @@ class TypeMismatchExceptionTest {
     }
 
     @Test
-    void shouldCreate_forMapKeyTypeMismatch() {
-        var ex = TypeMismatchException.forMapKeyTypeMismatch(String.class, Integer.class);
+    void shouldCreate_forUnexpectedMapKeyType() {
+        var ex = TypeMismatchException.forUnexpectedMapKeyType(String.class, Integer.class);
 
         assertAll(
             () -> assertThat(ex).hasMessage("Expected Map to contain keys of type java.lang.String, but found key of type java.lang.Integer"),
@@ -71,8 +71,8 @@ class TypeMismatchExceptionTest {
     }
 
     @Test
-    void shouldCreate_forMapValueTypeMismatch() {
-        var ex = TypeMismatchException.forMapValueTypeMismatch(Integer.class, Long.class);
+    void shouldCreate_forUnexpectedMapValueType() {
+        var ex = TypeMismatchException.forUnexpectedMapValueType(Integer.class, Long.class);
 
         assertAll(
             () -> assertThat(ex).hasMessage("Expected Map to contain values of type java.lang.Integer, but found value of type java.lang.Long"),

--- a/src/test/java/org/kiwiproject/beta/base/TypeMismatchExceptionTest.java
+++ b/src/test/java/org/kiwiproject/beta/base/TypeMismatchExceptionTest.java
@@ -2,51 +2,35 @@ package org.kiwiproject.beta.base;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.kiwiproject.test.junit.jupiter.StandardExceptionTests.standardConstructorTestsFor;
 
-import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestFactory;
 
-import java.util.Collection;
 import java.util.Set;
 
 class TypeMismatchExceptionTest {
-
-    @TestFactory
-    Collection<DynamicTest> shouldHaveStandardConstructors() {
-        return standardConstructorTestsFor(TypeMismatchException.class);
-    }
-
-    @Test
-    void shouldCreate_forExpectedTypeWithCause() {
-        var cause = new ClassCastException();
-        var ex = TypeMismatchException.forExpectedTypeWithCause(Double.class, cause);
-
-        assertAll(
-            () -> assertThat(ex).hasMessage("Cannot cast value to type java.lang.Double"),
-            () -> assertThat(ex).hasCause(cause)
-        );
-    }
 
     @Test
     void shouldCreate_forTypeMismatch_WithValueType_AndUnexpectedType() {
         var ex = TypeMismatchException.forUnexpectedType(Double.class, Integer.class);
 
-         assertAll(
-            () -> assertThat(ex).hasMessage("Cannot cast value of type java.lang.Integer to type java.lang.Double"),
-            () -> assertThat(ex).hasNoCause()
+        assertAll(
+                () -> assertThat(ex).hasMessage("Cannot cast value of type java.lang.Integer to type java.lang.Double"),
+                () -> assertThat(ex).hasNoCause(),
+                () -> assertThat(ex.expectedType()).isEqualTo(Double.class),
+                () -> assertThat(ex.actualType()).isEqualTo(Integer.class)
         );
     }
 
     @Test
-    void shouldCreate_forTypeMismatch_WithValueType_AndUnexpectedTypeh_AndClassCastExceptionAsCause() {
+    void shouldCreate_forTypeMismatch_WithValueType_AndUnexpectedType_AndClassCastExceptionAsCause() {
         var cause = new ClassCastException();
-        var ex = TypeMismatchException.forUnexpectedTypeWithCause(Double.class, Integer.class, cause);
+        var ex = TypeMismatchException.forUnexpectedTypeWithCause(String.class, Integer.class, cause);
 
-         assertAll(
-            () -> assertThat(ex).hasMessage("Cannot cast value of type java.lang.Integer to type java.lang.Double"),
-            () -> assertThat(ex).hasCause(cause)
+        assertAll(
+                () -> assertThat(ex).hasMessage("Cannot cast value of type java.lang.Integer to type java.lang.String"),
+                () -> assertThat(ex).hasCause(cause),
+                () -> assertThat(ex.expectedType()).isEqualTo(String.class),
+                () -> assertThat(ex.actualType()).isEqualTo(Integer.class)
         );
     }
 
@@ -55,8 +39,10 @@ class TypeMismatchExceptionTest {
         var ex = TypeMismatchException.forUnexpectedCollectionElementType(Set.class, Integer.class, Double.class);
 
         assertAll(
-            () -> assertThat(ex).hasMessage("Expected java.util.Set to contain elements of type java.lang.Integer, but found element of type java.lang.Double"),
-            () -> assertThat(ex).hasNoCause()
+                () -> assertThat(ex).hasMessage("Expected java.util.Set to contain elements of type java.lang.Integer, but found element of type java.lang.Double"),
+                () -> assertThat(ex).hasNoCause(),
+                () -> assertThat(ex.expectedType()).isEqualTo(Integer.class),
+                () -> assertThat(ex.actualType()).isEqualTo(Double.class)
         );
     }
 
@@ -65,8 +51,10 @@ class TypeMismatchExceptionTest {
         var ex = TypeMismatchException.forUnexpectedMapKeyType(String.class, Integer.class);
 
         assertAll(
-            () -> assertThat(ex).hasMessage("Expected Map to contain keys of type java.lang.String, but found key of type java.lang.Integer"),
-            () -> assertThat(ex).hasNoCause()
+                () -> assertThat(ex).hasMessage("Expected Map to contain keys of type java.lang.String, but found key of type java.lang.Integer"),
+                () -> assertThat(ex).hasNoCause(),
+                () -> assertThat(ex.expectedType()).isEqualTo(String.class),
+                () -> assertThat(ex.actualType()).isEqualTo(Integer.class)
         );
     }
 
@@ -75,8 +63,10 @@ class TypeMismatchExceptionTest {
         var ex = TypeMismatchException.forUnexpectedMapValueType(Integer.class, Long.class);
 
         assertAll(
-            () -> assertThat(ex).hasMessage("Expected Map to contain values of type java.lang.Integer, but found value of type java.lang.Long"),
-            () -> assertThat(ex).hasNoCause()
+                () -> assertThat(ex).hasMessage("Expected Map to contain values of type java.lang.Integer, but found value of type java.lang.Long"),
+                () -> assertThat(ex).hasNoCause(),
+                () -> assertThat(ex.expectedType()).isEqualTo(Integer.class),
+                () -> assertThat(ex.actualType()).isEqualTo(Long.class)
         );
     }
 }


### PR DESCRIPTION
Add the KiwiCasts2 utility class with methods to cast objects.
It provides specialized methods to cast objects to collections,
sets, lists, or maps that perform type checks of some objects
in those collections or maps. These methods can be useful
when you are deserializing deeply nested structures, e.g., from
JSON, and you want to validate that they contain the expected
types of object.