### PR TITLE
Add ability to escape a response entity when the content type HTML

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,8 @@
         <!-- Versions for test dependencies -->
         <kiwi-test.version>3.11.0</kiwi-test.version>
         <mockito-kotlin.version>5.4.0</mockito-kotlin.version>
+        <!-- TODO: Remove this property once update to kiwi-bom 2.0.27 (see https://github.com/kiwiproject/kiwi-bom/issues/1313) -->
+        <okhttp3.mockwebserver.version>4.12.0</okhttp3.mockwebserver.version>
 
         <!--  Sonar properties -->
         <sonar.projectKey>sleberknight_kiwi-beta</sonar.projectKey>
@@ -272,6 +274,12 @@
 
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-common</artifactId>
             <scope>test</scope>
         </dependency>
@@ -299,6 +307,14 @@
                     <artifactId>mockito-core</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <!-- TODO: Remove version once update to kiwi-bom 2.0.27 (see https://github.com/kiwiproject/kiwi-bom/issues/1313) -->
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>${okhttp3.mockwebserver.version}</version>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/src/main/java/org/kiwiproject/beta/jakarta/rest/KiwiResponses2.java
+++ b/src/main/java/org/kiwiproject/beta/jakarta/rest/KiwiResponses2.java
@@ -1,0 +1,53 @@
+package org.kiwiproject.beta.jakarta.rest;
+
+import static java.util.Objects.nonNull;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
+
+import jakarta.ws.rs.core.Response;
+import lombok.experimental.UtilityClass;
+import org.kiwiproject.beta.net.KiwiHttpResponses2;
+
+/**
+ * Utilities related to Jakarta REST {@link Response}.
+ * <p>
+ * Some of these methods eventually may be moved into {@code org.kiwiproject.jaxrs.KiwiResponses}
+ * in <a href="https://github.com/kiwiproject/kiwi">kiwi</a>.
+ */
+@UtilityClass
+public class KiwiResponses2 {
+
+    /**
+     * If the {@link Response} is HTML, return the escaped entity.
+     * Otherwise, return the original response entity.
+     * <p>
+     * If the response has no entity, an empty string is returned to be
+     * consistent with the behavior of {@link Response} when reading
+     * the entity as a String.
+     * <p>
+     * <strong>Note:</strong>
+     * The {@code response} must not be closed, and the entity cannot
+     * have already been read. These are transitive restrictions from
+     * the {@link Response#readEntity(Class) readEntity} method, which
+     * is used to read the entity. An {@code IllegalStateException} is
+     * thrown if either of these restrictions is violated. Also note that
+     * the response will be closed after this method returns, again
+     * because of {@code readEntity}.
+     *
+     * @param response the {@link Response} from which to read and escape the entity
+     * @return the HTML-escaped entity if the response is HTML, otherwise the original entity
+     * @throws IllegalArgumentException if {@code response} is null
+     * @throws IllegalStateException if the {@code response} is closed or the entity has
+     * already been consumed
+     * @see Response#readEntity(Class)
+     */
+    public static String htmlEscapeEntity(Response response) {
+        checkArgumentNotNull(response, "response must not be null");
+
+        var entity = response.readEntity(String.class);
+        var mediaType = response.getMediaType();
+        if (nonNull(mediaType)) {
+            return KiwiHttpResponses2.htmlEscape(entity, mediaType.toString());
+        }
+        return entity;
+    }
+}

--- a/src/main/java/org/kiwiproject/beta/jakarta/rest/KiwiResponses2.java
+++ b/src/main/java/org/kiwiproject/beta/jakarta/rest/KiwiResponses2.java
@@ -3,6 +3,7 @@ package org.kiwiproject.beta.jakarta.rest;
 import static java.util.Objects.nonNull;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 
+import com.google.common.annotations.Beta;
 import jakarta.ws.rs.core.Response;
 import lombok.experimental.UtilityClass;
 import org.kiwiproject.beta.net.KiwiHttpResponses2;
@@ -14,6 +15,7 @@ import org.kiwiproject.beta.net.KiwiHttpResponses2;
  * in <a href="https://github.com/kiwiproject/kiwi">kiwi</a>.
  */
 @UtilityClass
+@Beta
 public class KiwiResponses2 {
 
     /**

--- a/src/main/java/org/kiwiproject/beta/net/KiwiHttpResponses2.java
+++ b/src/main/java/org/kiwiproject/beta/net/KiwiHttpResponses2.java
@@ -1,0 +1,38 @@
+package org.kiwiproject.beta.net;
+
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotBlank;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
+
+import com.google.common.html.HtmlEscapers;
+import lombok.experimental.UtilityClass;
+
+/**
+ * Utilities related to HTTP responses.
+ * <p>
+ * Some of these methods may eventually be moved into {@code org.kiwiproject.net.KiwiHttpResponses}
+ * in <a href="https://github.com/kiwiproject/kiwi">kiwi</a>. 
+ */
+@UtilityClass
+public class KiwiHttpResponses2 {
+
+    /**
+     * If the {@code mediaType} is HTML ({@code text/html}), return the escaped entity.
+     * Otherwise, return {@code entity} without modification.
+     * 
+     * @param entity the response entity
+     * @param mediaType the media type to evaluate
+     * @return the HTML-escaped entity if the response is HTML, otherwise the original entity
+     * @throws IllegalArgumentException if {@code entity} is null or {@code mediaType} is blank
+     * @see HtmlEscapers
+     */
+    public static String htmlEscape(String entity, String mediaType) {
+        checkArgumentNotNull(entity, "entity must not be null");
+        checkArgumentNotBlank(mediaType, "mediaType must not be blank");
+
+        if (KiwiMediaTypes.isHtml(mediaType)) {
+            return HtmlEscapers.htmlEscaper().escape(entity);
+        }
+
+        return entity;
+    }
+}

--- a/src/main/java/org/kiwiproject/beta/net/KiwiHttpResponses2.java
+++ b/src/main/java/org/kiwiproject/beta/net/KiwiHttpResponses2.java
@@ -3,6 +3,7 @@ package org.kiwiproject.beta.net;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotBlank;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 
+import com.google.common.annotations.Beta;
 import com.google.common.html.HtmlEscapers;
 import lombok.experimental.UtilityClass;
 
@@ -13,6 +14,7 @@ import lombok.experimental.UtilityClass;
  * in <a href="https://github.com/kiwiproject/kiwi">kiwi</a>. 
  */
 @UtilityClass
+@Beta
 public class KiwiHttpResponses2 {
 
     /**

--- a/src/test/java/org/kiwiproject/beta/jakarta/rest/KiwiResponses2Test.java
+++ b/src/test/java/org/kiwiproject/beta/jakarta/rest/KiwiResponses2Test.java
@@ -1,0 +1,145 @@
+package org.kiwiproject.beta.jakarta.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+
+import com.google.common.net.HttpHeaders;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Response;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.glassfish.jersey.internal.LocalizationMessages;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.kiwiproject.test.okhttp3.mockwebserver.MockWebServerExtension;
+
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+
+@DisplayName("KiwiResponses2")
+class KiwiResponses2Test {
+
+    @RegisterExtension
+    private final MockWebServerExtension serverExtension = new MockWebServerExtension();
+
+    private MockWebServer server;
+    private Client client;
+    private URI baseUri;
+
+    @BeforeEach
+    void setUp() {
+        client = ClientBuilder.newBuilder()
+                .connectTimeout(500, TimeUnit.MILLISECONDS)
+                .readTimeout(500, TimeUnit.MILLISECONDS)
+                .build();
+
+        server = serverExtension.server();
+        baseUri = serverExtension.uri();
+    }
+
+    @Test
+    void shouldThrow_IllegalArgument_WhenResponseIsNull() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> KiwiResponses2.htmlEscapeEntity(null))
+                .withMessage("response must not be null");
+    }   
+
+    @Test
+    void shouldThrow_IllegalState_WhenResponseEntity_IsAlreadyConsumed() {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader(HttpHeaders.CONTENT_TYPE, "text/html")
+                .setBody("<p>Hello, world</p>"));
+        
+        var response = makeRequest();
+
+        // Consume the entity
+        response.readEntity(String.class);
+
+        // Now try to escape it
+        assertThatIllegalStateException()
+                .describedAs("Should get IllegalStateException when response entity has been consumed")
+                .isThrownBy(() -> KiwiResponses2.htmlEscapeEntity(response))
+                .withMessage(LocalizationMessages.ERROR_ENTITY_STREAM_CLOSED());
+    }
+
+     @Test
+    void shouldThrow_IllegalState_WhenResponse_IsClosed() {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader(HttpHeaders.CONTENT_TYPE, "text/html")
+                .setBody("<p>Hello, world</p>"));
+        
+        var response = makeRequest();
+        
+        // Close the response (without reading the entity)
+        response.close();
+
+        // Now try to escape it
+        assertThatIllegalStateException()
+                .describedAs("Should get IllegalStateException when response is closed")
+                .isThrownBy(() -> KiwiResponses2.htmlEscapeEntity(response))
+                .withMessage(LocalizationMessages.ERROR_ENTITY_STREAM_CLOSED());
+    }
+
+    @Test
+    void shouldEscape_HtmlResponses() {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader(HttpHeaders.CONTENT_TYPE, "text/html")
+                .setBody("<p>Hello, world</p>"));
+        
+        var response = makeRequest();
+
+        var text = KiwiResponses2.htmlEscapeEntity(response);
+        
+        assertThat(text).isEqualTo("&lt;p&gt;Hello, world&lt;/p&gt;");
+    }
+
+    @Test
+    void shouldNotEscape_NonHtmlResponses() {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader(HttpHeaders.CONTENT_TYPE, "text/plain")
+                .setBody("Hello, world"));
+        
+        var response = makeRequest();
+
+        var text = KiwiResponses2.htmlEscapeEntity(response);
+
+        assertThat(text).isEqualTo("Hello, world");
+    }
+
+    @Test
+    void shouldReturnEmptyString_WhenResponseHasZeroLengthContent() {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader(HttpHeaders.CONTENT_LENGTH, 0));
+
+        var response = makeRequest();
+
+        var text = KiwiResponses2.htmlEscapeEntity(response);
+
+        assertThat(text).isEmpty();
+    }
+
+    @Test
+    void shouldReturnEmptyString_WhenResponseHasNoBody() {
+        server.enqueue(new MockResponse()
+                .setResponseCode(204));
+
+        var response = makeRequest();
+
+        var text = KiwiResponses2.htmlEscapeEntity(response);
+
+        assertThat(text).isEmpty();
+    }
+
+    private Response makeRequest() {
+        return client.target(baseUri).request().get();
+    }
+}

--- a/src/test/java/org/kiwiproject/beta/net/KiwiHttpResponses2Test.java
+++ b/src/test/java/org/kiwiproject/beta/net/KiwiHttpResponses2Test.java
@@ -1,0 +1,49 @@
+package org.kiwiproject.beta.net;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.kiwiproject.test.junit.jupiter.params.provider.AsciiOnlyBlankStringSource;
+
+@DisplayName("KiwiHttpResponses2")
+class KiwiHttpResponses2Test {
+
+    @Test
+    void shouldThrow_IllegalArgument_WhenResponseIsNull() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> KiwiHttpResponses2.htmlEscape(null, "text/html"))
+                .withMessage("entity must not be null");
+    }   
+
+    @ParameterizedTest
+    @AsciiOnlyBlankStringSource
+    void shouldThrow_IllegalArgument_WhenMediaTypeIsBlank(String mediaType) {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> KiwiHttpResponses2.htmlEscape("<p>Hello</p>", mediaType))
+                .withMessage("mediaType must not be blank");
+    } 
+
+    @Test
+    void shouldEscape_HtmlContent() {
+        var text = KiwiHttpResponses2.htmlEscape("<p>Hello, world</p>", "text/html");
+        
+        assertThat(text).isEqualTo("&lt;p&gt;Hello, world&lt;/p&gt;");
+    }
+
+    @Test
+    void shouldNotEscape_NonHtmlContent() {
+        var text = KiwiHttpResponses2.htmlEscape("Hello, world", "text/plain");
+
+        assertThat(text).isEqualTo("Hello, world");
+    }
+
+    @Test
+    void shouldReturnEmptyString_WhenContentIsEmpty() {
+       var text = KiwiHttpResponses2.htmlEscape("", "text/html");
+
+        assertThat(text).isEmpty();
+    }
+}


### PR DESCRIPTION
Add KiwiHttpResponses2 with a single method: htmlEscape.

Add KiwiResponses2 with a single method: htmlEscapeEnity.

KiwiResponses2 handles HTML escaping when using Jakarta REST. You pass a Jakarta REST Response to htmlEscape.

It delegates to KiwiHttpResponses2, which handles HTML escaping in a generic manner. The htmlEscape method accepts two Strings: the (response) entity to be HTML-escaped, and the media type.

In both methods, if the media type is not HTML, then no escaping is performed.

Added jersey-client and the OkHttp mockwebserver as test-scoped dependencies.

Closes #523