### PR TITLE
feat: deprecate KiwiSlf4j log methods for removal

### DIFF
--- a/src/main/java/org/kiwiproject/beta/slf4j/KiwiSlf4j.java
+++ b/src/main/java/org/kiwiproject/beta/slf4j/KiwiSlf4j.java
@@ -4,26 +4,48 @@ import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotBlank;
 
 import com.google.common.annotations.Beta;
 import lombok.experimental.UtilityClass;
+import org.kiwiproject.base.KiwiDeprecated;
 import org.slf4j.Logger;
 import org.slf4j.event.Level;
 
 import java.util.Locale;
 
 /**
- * Utilities for SLF4J, mainly to allow logging a message at a specified level. Sometimes it is useful to be able
- * not just to change the log level of loggers at runtime, but also to select the level of specific log statements.
- * For example, instead of having to hard code a {@code LOG.debug(...)}, you can use one of the {@code log} methods
- * in this utility to permit changing the level at which a specific statement is logged. This is more granular than
- * just changing an entire Logger's level and is extremely useful in some situations.
+ * Utilities for working with SLF4J {@link Logger} instances and {@link Level} values.
+ * <p>
+ * Sometimes it is useful to select a logging level dynamically instead of hard-coding
+ * calls such as {@code LOG.debug(...)} or {@code LOG.info(...)}. This class provides
+ * helpers for checking whether a logger is enabled for a dynamically selected level,
+ * and for converting level names to SLF4J {@link Level} values in a case-insensitive way.
+ * <p>
+ * The {@code log} methods are deprecated since SLF4J 2 provides equivalent functionality
+ * via its fluent logging API, e.g. {@code logger.atLevel(level).log(message)}.
  */
 @UtilityClass
 @Beta
 public class KiwiSlf4j {
 
+    /**
+     * Returns whether the given logger is enabled for the level represented by the given level name.
+     * <p>
+     * The level name is matched case-insensitively using {@link #toLevelIgnoreCase(String)}.
+     *
+     * @param logger the SLF4J logger to check
+     * @param levelName the name of the SLF4J level to check
+     * @return true if the logger is enabled for the matching level; otherwise false
+     * @throws IllegalArgumentException if {@code levelName} is blank or there is no matching {@link Level}
+     */
     public static boolean isEnabled(Logger logger, String levelName) {
         return isEnabled(logger, toLevelIgnoreCase(levelName));
     }
 
+    /**
+     * Returns whether the given logger is enabled for the given SLF4J level.
+     *
+     * @param logger the SLF4J logger to check
+     * @param level the SLF4J level to check
+     * @return true if the logger is enabled for the given level; otherwise false
+     */
     public static boolean isEnabled(Logger logger, Level level) {
         return switch (level) {
             case ERROR -> logger.isErrorEnabled();
@@ -34,10 +56,28 @@ public class KiwiSlf4j {
         };
     }
 
+    /**
+     * @deprecated replaced by {@code logger.atLevel(KiwiSlf4j.toLevelIgnoreCase(levelName)).log(message)}
+     */
+    @KiwiDeprecated(
+        removeAt = "4.0.0",
+        replacedBy = "logger.atLevel(KiwiSlf4j.toLevelIgnoreCase(levelName)).log(message)",
+        reference = "https://github.com/sleberknight/kiwi-beta/issues/613"
+    )
+    @Deprecated(since = "3.1.0", forRemoval = true)
     public static void log(Logger logger, String levelName, String message) {
         log(logger, toLevelIgnoreCase(levelName), message);
     }
 
+    /**
+     * @deprecated replaced by {@code logger.atLevel(level).log(message)}
+     */
+    @KiwiDeprecated(
+        removeAt = "4.0.0",
+        replacedBy = "logger.atLevel(level).log(message)",
+        reference = "https://github.com/sleberknight/kiwi-beta/issues/613"
+    )
+    @Deprecated(since = "3.1.0", forRemoval = true)
     public static void log(Logger logger, Level level, String message) {
         switch (level) {
             case ERROR -> logger.error(message);
@@ -48,10 +88,28 @@ public class KiwiSlf4j {
         }
     }
 
+    /**
+     * @deprecated replaced by {@code logger.atLevel(KiwiSlf4j.toLevelIgnoreCase(levelName)).log(format, arg)}
+     */
+    @KiwiDeprecated(
+        removeAt = "4.0.0",
+        replacedBy = "logger.atLevel(KiwiSlf4j.toLevelIgnoreCase(levelName)).log(format, arg)",
+        reference = "https://github.com/sleberknight/kiwi-beta/issues/613"
+    )
+    @Deprecated(since = "3.1.0", forRemoval = true)
     public static void log(Logger logger, String levelName, String format, Object arg) {
         log(logger, toLevelIgnoreCase(levelName), format, arg);
     }
 
+    /**
+     * @deprecated replaced by {@code logger.atLevel(level).log(format, arg)}
+     */
+    @KiwiDeprecated(
+        removeAt = "4.0.0",
+        replacedBy = "logger.atLevel(level).log(format, arg)",
+        reference = "https://github.com/sleberknight/kiwi-beta/issues/613"
+    )
+    @Deprecated(since = "3.1.0", forRemoval = true)
     @SuppressWarnings("DuplicatedCode")
     public static void log(Logger logger, Level level, String format, Object arg) {
         switch (level) {
@@ -63,10 +121,28 @@ public class KiwiSlf4j {
         }
     }
 
+    /**
+     * @deprecated replaced by {@code logger.atLevel(KiwiSlf4j.toLevelIgnoreCase(levelName)).log(format, arg1, arg2)}
+     */
+    @KiwiDeprecated(
+        removeAt = "4.0.0",
+        replacedBy = "logger.atLevel(KiwiSlf4j.toLevelIgnoreCase(levelName)).log(format, arg1, arg2)",
+        reference = "https://github.com/sleberknight/kiwi-beta/issues/613"
+    )
+    @Deprecated(since = "3.1.0", forRemoval = true)
     public static void log(Logger logger, String levelName, String format, Object arg1, Object arg2) {
         log(logger, toLevelIgnoreCase(levelName), format, arg1, arg2);
     }
 
+    /**
+     * @deprecated replaced by {@code logger.atLevel(level).log(format, arg1, arg2)}
+     */
+    @KiwiDeprecated(
+        removeAt = "4.0.0",
+        replacedBy = "logger.atLevel(level).log(format, arg1, arg2)",
+        reference = "https://github.com/sleberknight/kiwi-beta/issues/613"
+    )
+    @Deprecated(since = "3.1.0", forRemoval = true)
     public static void log(Logger logger, Level level, String format, Object arg1, Object arg2) {
         switch (level) {
             case ERROR -> logger.error(format, arg1, arg2);
@@ -77,10 +153,28 @@ public class KiwiSlf4j {
         }
     }
 
+    /**
+     * @deprecated replaced by {@code logger.atLevel(KiwiSlf4j.toLevelIgnoreCase(levelName)).log(format, arguments)}
+     */
+    @KiwiDeprecated(
+        removeAt = "4.0.0",
+        replacedBy = "logger.atLevel(KiwiSlf4j.toLevelIgnoreCase(levelName)).log(format, arguments)",
+        reference = "https://github.com/sleberknight/kiwi-beta/issues/613"
+    )
+    @Deprecated(since = "3.1.0", forRemoval = true)
     public static void log(Logger logger, String levelName, String format, Object... arguments) {
         log(logger, toLevelIgnoreCase(levelName), format, arguments);
     }
 
+    /**
+     * @deprecated replaced by {@code logger.atLevel(level).log(format, arguments)}
+     */
+    @KiwiDeprecated(
+        removeAt = "4.0.0",
+        replacedBy = "logger.atLevel(level).log(format, arguments)",
+        reference = "https://github.com/sleberknight/kiwi-beta/issues/613"
+    )
+    @Deprecated(since = "3.1.0", forRemoval = true)
     @SuppressWarnings("DuplicatedCode")
     public static void log(Logger logger, Level level, String format, Object... arguments) {
         switch (level) {
@@ -92,10 +186,28 @@ public class KiwiSlf4j {
         }
     }
 
+    /**
+     * @deprecated replaced by {@code logger.atLevel(KiwiSlf4j.toLevelIgnoreCase(levelName)).setCause(t).log(message)}
+     */
+    @KiwiDeprecated(
+        removeAt = "4.0.0",
+        replacedBy = "logger.atLevel(KiwiSlf4j.toLevelIgnoreCase(levelName)).setCause(t).log(message)",
+        reference = "https://github.com/sleberknight/kiwi-beta/issues/613"
+    )
+    @Deprecated(since = "3.1.0", forRemoval = true)
     public static void log(Logger logger, String levelName, String message, Throwable t) {
         log(logger, toLevelIgnoreCase(levelName), message, t);
     }
 
+    /**
+     * @deprecated replaced by {@code logger.atLevel(level).setCause(t).log(message)}
+     */
+    @KiwiDeprecated(
+        removeAt = "4.0.0",
+        replacedBy = "logger.atLevel(level).setCause(t).log(message)",
+        reference = "https://github.com/sleberknight/kiwi-beta/issues/613"
+    )
+    @Deprecated(since = "3.1.0", forRemoval = true)
     @SuppressWarnings("DuplicatedCode")
     public static void log(Logger logger, Level level, String message, Throwable t) {
         switch (level) {

--- a/src/main/java/org/kiwiproject/beta/slf4j/KiwiSlf4j.java
+++ b/src/main/java/org/kiwiproject/beta/slf4j/KiwiSlf4j.java
@@ -23,6 +23,7 @@ import java.util.Locale;
  */
 @UtilityClass
 @Beta
+@SuppressWarnings("java:S1133")
 public class KiwiSlf4j {
 
     /**

--- a/src/main/kotlin/org/kiwiproject/beta/slf4j/KiwiSlf4jExtensions.kt
+++ b/src/main/kotlin/org/kiwiproject/beta/slf4j/KiwiSlf4jExtensions.kt
@@ -9,12 +9,14 @@ fun Logger.isEnabled(level: Level): Boolean = KiwiSlf4j.isEnabled(this, level)
     message = "Use SLF4J's fluent logging API: logger.atLevel(level).log(message)",
     replaceWith = ReplaceWith("this.atLevel(level).log(message)")
 )
+@Suppress("DEPRECATION", "kotlin:S1874", "kotlin:S1133")
 fun Logger.log(level: Level, message: String) = KiwiSlf4j.log(this, level, message)
 
 @Deprecated(
     message = "Use SLF4J's fluent logging API: logger.atLevel(level).log(format, arg)",
     replaceWith = ReplaceWith("this.atLevel(level).log(format, arg)")
 )
+@Suppress("DEPRECATION", "kotlin:S1874", "kotlin:S1133")
 fun Logger.log(level: Level, format: String, arg: Any) =
     KiwiSlf4j.log(this, level, format, arg)
 
@@ -22,17 +24,18 @@ fun Logger.log(level: Level, format: String, arg: Any) =
     message = "Use SLF4J's fluent logging API: logger.atLevel(level).log(format, arg1, arg2)",
     replaceWith = ReplaceWith("this.atLevel(level).log(format, arg1, arg2)")
 )
+@Suppress("DEPRECATION", "kotlin:S1874", "kotlin:S1133")
 fun Logger.log(level: Level, format: String, arg1: Any, arg2: Any) =
     KiwiSlf4j.log(this, level, format, arg1, arg2)
 
 // Add guard around log to avoid an array copy by the spread operator unless actually necessary.
 // I don't know how else to "fix" the use of the spread operator here.
 // See https://detekt.github.io/detekt/performance.html#spreadoperator for more information
-@Suppress("SpreadOperator")
 @Deprecated(
     message = "Use SLF4J's fluent logging API: logger.atLevel(level).log(format, *arguments)",
     replaceWith = ReplaceWith("this.atLevel(level).log(format, *arguments)")
 )
+@Suppress("DEPRECATION", "SpreadOperator", "kotlin:S1874", "kotlin:S1133")
 fun Logger.log(level: Level, format: String, vararg arguments: Any) {
     if (isEnabled(level)) {
         KiwiSlf4j.log(this, level, format, *arguments)
@@ -43,5 +46,6 @@ fun Logger.log(level: Level, format: String, vararg arguments: Any) {
     message = "Use SLF4J's fluent logging API: logger.atLevel(level).log(message, t)",
     replaceWith = ReplaceWith("this.atLevel(level).setCause(t).log(message)")
 )
+@Suppress("DEPRECATION", "kotlin:S1874", "kotlin:S1133")
 fun Logger.log(level: Level, message: String, t: Throwable) =
     KiwiSlf4j.log(this, level, message, t)

--- a/src/main/kotlin/org/kiwiproject/beta/slf4j/KiwiSlf4jExtensions.kt
+++ b/src/main/kotlin/org/kiwiproject/beta/slf4j/KiwiSlf4jExtensions.kt
@@ -9,14 +9,14 @@ fun Logger.isEnabled(level: Level): Boolean = KiwiSlf4j.isEnabled(this, level)
     message = "Use SLF4J's fluent logging API: logger.atLevel(level).log(message)",
     replaceWith = ReplaceWith("this.atLevel(level).log(message)")
 )
-@Suppress("DEPRECATION", "kotlin:S1874", "kotlin:S1133")
+@Suppress("DEPRECATION", "removal", "kotlin:S1874", "kotlin:S1133")
 fun Logger.log(level: Level, message: String) = KiwiSlf4j.log(this, level, message)
 
 @Deprecated(
     message = "Use SLF4J's fluent logging API: logger.atLevel(level).log(format, arg)",
     replaceWith = ReplaceWith("this.atLevel(level).log(format, arg)")
 )
-@Suppress("DEPRECATION", "kotlin:S1874", "kotlin:S1133")
+@Suppress("DEPRECATION", "removal", "kotlin:S1874", "kotlin:S1133")
 fun Logger.log(level: Level, format: String, arg: Any) =
     KiwiSlf4j.log(this, level, format, arg)
 
@@ -24,7 +24,7 @@ fun Logger.log(level: Level, format: String, arg: Any) =
     message = "Use SLF4J's fluent logging API: logger.atLevel(level).log(format, arg1, arg2)",
     replaceWith = ReplaceWith("this.atLevel(level).log(format, arg1, arg2)")
 )
-@Suppress("DEPRECATION", "kotlin:S1874", "kotlin:S1133")
+@Suppress("DEPRECATION", "removal", "kotlin:S1874", "kotlin:S1133")
 fun Logger.log(level: Level, format: String, arg1: Any, arg2: Any) =
     KiwiSlf4j.log(this, level, format, arg1, arg2)
 
@@ -35,7 +35,7 @@ fun Logger.log(level: Level, format: String, arg1: Any, arg2: Any) =
     message = "Use SLF4J's fluent logging API: logger.atLevel(level).log(format, *arguments)",
     replaceWith = ReplaceWith("this.atLevel(level).log(format, *arguments)")
 )
-@Suppress("DEPRECATION", "SpreadOperator", "kotlin:S1874", "kotlin:S1133")
+@Suppress("DEPRECATION", "removal", "SpreadOperator", "kotlin:S1874", "kotlin:S1133")
 fun Logger.log(level: Level, format: String, vararg arguments: Any) {
     if (isEnabled(level)) {
         KiwiSlf4j.log(this, level, format, *arguments)
@@ -46,6 +46,6 @@ fun Logger.log(level: Level, format: String, vararg arguments: Any) {
     message = "Use SLF4J's fluent logging API: logger.atLevel(level).log(message, t)",
     replaceWith = ReplaceWith("this.atLevel(level).setCause(t).log(message)")
 )
-@Suppress("DEPRECATION", "kotlin:S1874", "kotlin:S1133")
+@Suppress("DEPRECATION", "removal", "kotlin:S1874", "kotlin:S1133")
 fun Logger.log(level: Level, message: String, t: Throwable) =
     KiwiSlf4j.log(this, level, message, t)

--- a/src/main/kotlin/org/kiwiproject/beta/slf4j/KiwiSlf4jExtensions.kt
+++ b/src/main/kotlin/org/kiwiproject/beta/slf4j/KiwiSlf4jExtensions.kt
@@ -5,11 +5,23 @@ import org.slf4j.event.Level
 
 fun Logger.isEnabled(level: Level): Boolean = KiwiSlf4j.isEnabled(this, level)
 
+@Deprecated(
+    message = "Use SLF4J's fluent logging API: logger.atLevel(level).log(message)",
+    replaceWith = ReplaceWith("this.atLevel(level).log(message)")
+)
 fun Logger.log(level: Level, message: String) = KiwiSlf4j.log(this, level, message)
 
+@Deprecated(
+    message = "Use SLF4J's fluent logging API: logger.atLevel(level).log(format, arg)",
+    replaceWith = ReplaceWith("this.atLevel(level).log(format, arg)")
+)
 fun Logger.log(level: Level, format: String, arg: Any) =
     KiwiSlf4j.log(this, level, format, arg)
 
+@Deprecated(
+    message = "Use SLF4J's fluent logging API: logger.atLevel(level).log(format, arg1, arg2)",
+    replaceWith = ReplaceWith("this.atLevel(level).log(format, arg1, arg2)")
+)
 fun Logger.log(level: Level, format: String, arg1: Any, arg2: Any) =
     KiwiSlf4j.log(this, level, format, arg1, arg2)
 
@@ -17,11 +29,19 @@ fun Logger.log(level: Level, format: String, arg1: Any, arg2: Any) =
 // I don't know how else to "fix" the use of the spread operator here.
 // See https://detekt.github.io/detekt/performance.html#spreadoperator for more information
 @Suppress("SpreadOperator")
+@Deprecated(
+    message = "Use SLF4J's fluent logging API: logger.atLevel(level).log(format, *arguments)",
+    replaceWith = ReplaceWith("this.atLevel(level).log(format, *arguments)")
+)
 fun Logger.log(level: Level, format: String, vararg arguments: Any) {
     if (isEnabled(level)) {
         KiwiSlf4j.log(this, level, format, *arguments)
     }
 }
 
+@Deprecated(
+    message = "Use SLF4J's fluent logging API: logger.atLevel(level).log(message, t)",
+    replaceWith = ReplaceWith("this.atLevel(level).setCause(t).log(message)")
+)
 fun Logger.log(level: Level, message: String, t: Throwable) =
     KiwiSlf4j.log(this, level, message, t)

--- a/src/test/java/org/kiwiproject/beta/slf4j/KiwiSlf4jTest.java
+++ b/src/test/java/org/kiwiproject/beta/slf4j/KiwiSlf4jTest.java
@@ -28,7 +28,7 @@ import java.util.Locale;
  * @implNote See the loggers defined for this test in {@code src/test/resources/logback-test.xml}.
  */
 @DisplayName("KiwiSlf4j")
-@SuppressWarnings("java:S1133")
+@SuppressWarnings({"java:S1133", "removal"})
 class KiwiSlf4jTest {
 
     private static final String TEST_CLASS_NAME = KiwiSlf4jTest.class.getName();

--- a/src/test/java/org/kiwiproject/beta/slf4j/KiwiSlf4jTest.java
+++ b/src/test/java/org/kiwiproject/beta/slf4j/KiwiSlf4jTest.java
@@ -28,6 +28,7 @@ import java.util.Locale;
  * @implNote See the loggers defined for this test in {@code src/test/resources/logback-test.xml}.
  */
 @DisplayName("KiwiSlf4j")
+@SuppressWarnings("java:S1133")
 class KiwiSlf4jTest {
 
     private static final String TEST_CLASS_NAME = KiwiSlf4jTest.class.getName();

--- a/src/test/java/org/kiwiproject/beta/slf4j/KiwiSlf4jTest.java
+++ b/src/test/java/org/kiwiproject/beta/slf4j/KiwiSlf4jTest.java
@@ -28,7 +28,7 @@ import java.util.Locale;
  * @implNote See the loggers defined for this test in {@code src/test/resources/logback-test.xml}.
  */
 @DisplayName("KiwiSlf4j")
-@SuppressWarnings({"java:S1133", "removal"})
+@SuppressWarnings({"java:S1133", "java:S5738", "removal"})
 class KiwiSlf4jTest {
 
     private static final String TEST_CLASS_NAME = KiwiSlf4jTest.class.getName();


### PR DESCRIPTION
Deprecates the KiwiSlf4j#log methods in favor of SLF4J 2's fluent logging API.

The class remains useful for isEnabled helpers and case-insensitive conversion of string level names to SLF4J Level values.

Also adds minimal deprecation Javadocs and Kotlin ReplaceWith suggestions for the extension functions.

Document the remaining methods that are not deprecated and which do not already have Javadoc.

Closes #613