### PR TITLE
feat: add convenience methods to Timing result classes

### DIFF
--- a/src/main/java/org/kiwiproject/beta/time/Timing.java
+++ b/src/main/java/org/kiwiproject/beta/time/Timing.java
@@ -64,7 +64,7 @@ public class Timing {
     /**
      * Represents an operation that is timed and returns a result.
      *
-     * @param <R> the result type
+     * @param <R> the result type; the result may be null
      */
     @Getter
     @ToString
@@ -75,20 +75,22 @@ public class Timing {
 
         private final long elapsedMillis;
         private final long elapsedNanos;
+
+        @Nullable
         private final R result;
 
         /**
-         * @deprecated since 3.0.0, for removal at 4.0.0, replaced by {@link #ofElapsedNanos(long, Object)}
+         * @deprecated since 3.0.0, for removal at 4.0.0, replaced by {@link #ofElapsedMillis(long, Object)}
          * @implNote Technically, this won't be removed but will become private.
          */
         @KiwiDeprecated(
                 removeAt = "4.0.0",
-                replacedBy = "TimedNoResult#ofElapsedMillis"
+                replacedBy = "TimedWithResult#ofElapsedMillis"
         )
         @Deprecated(since = "3.0.0", forRemoval = true)
         @SuppressWarnings({"java:S1133", "DeprecatedIsStillUsed"})
         @ConstructorProperties({"elapsedMillis", "result"})
-        public TimedWithResult(long elapsedMillis, R result) {
+        public TimedWithResult(long elapsedMillis, @Nullable R result) {
             logElapsedMillisChangeToNanosWarning(TimedWithResult.class, LOG_COUNT);
             this.elapsedMillis = elapsedMillis;
             this.elapsedNanos = TimeUnit.MILLISECONDS.toNanos(elapsedMillis);
@@ -104,7 +106,7 @@ public class Timing {
          * @return a new instance
          */
         @SuppressWarnings("java:S5738")
-        public static <R> TimedWithResult<R> ofElapsedMillis(long elapsedMillis, R result) {
+        public static <R> TimedWithResult<R> ofElapsedMillis(long elapsedMillis, @Nullable R result) {
             return new TimedWithResult<>(elapsedMillis, result);
         }
 
@@ -117,7 +119,7 @@ public class Timing {
          * @return a new instance
          */
         @SuppressWarnings("java:S5738")
-        public static <R> TimedWithResult<R> ofElapsedNanos(long elapsedNanos, R result) {
+        public static <R> TimedWithResult<R> ofElapsedNanos(long elapsedNanos, @Nullable R result) {
             return new TimedWithResult<>(TimeUnit.NANOSECONDS.toMillis(elapsedNanos), result);
         }
 
@@ -310,8 +312,7 @@ public class Timing {
         /**
          * Returns the exception if the operation failed, or null if it succeeded.
          * <p>
-         * Note: a null return value does not distinguish between "the operation
-         * succeeded" and "no exception was thrown" — use {@link #hasException()}
+         * A null return value means the operation succeeded. Use {@link #hasException()}
          * or {@link #operationSucceeded()} for explicit checks.
          *
          * @return the exception thrown by the operation, or null if the operation succeeded
@@ -369,7 +370,7 @@ public class Timing {
          * @throws IllegalArgumentException if both result and exception are non-null
          */
         @VisibleForTesting
-        TimedWithErrorOrResult(long elapsedNanos, R result, RuntimeException exception) {
+        TimedWithErrorOrResult(long elapsedNanos, @Nullable R result, RuntimeException exception) {
             if (nonNull(result) && nonNull(exception)) {
                 throw new IllegalArgumentException("Cannot contain a result and an exception");
             }
@@ -387,7 +388,7 @@ public class Timing {
          * @param result the result of the operation; may be null
          * @return a new instance representing a successful operation
          */
-        public static <R> TimedWithErrorOrResult<R> ofResult(long elapsedNanos, R result) {
+        public static <R> TimedWithErrorOrResult<R> ofResult(long elapsedNanos, @Nullable R result) {
             return new TimedWithErrorOrResult<>(elapsedNanos, result, null);
         }
 
@@ -445,6 +446,7 @@ public class Timing {
          * succeeded with a null result
          * @throws IllegalStateException if the operation failed (i.e., threw an exception)
          */
+        @Nullable
         public R getRequiredResult() {
             if (hasResult()) {
                 return result;

--- a/src/main/java/org/kiwiproject/beta/time/Timing.java
+++ b/src/main/java/org/kiwiproject/beta/time/Timing.java
@@ -15,9 +15,11 @@ import lombok.Value;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.time.StopWatch;
+import org.jspecify.annotations.Nullable;
 import org.kiwiproject.base.KiwiDeprecated;
 
 import java.beans.ConstructorProperties;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -48,6 +50,15 @@ public class Timing {
          * @return the number of nanoseconds that elapsed during the operation
          */
         long getElapsedNanos();
+
+        /**
+         * Returns the elapsed time of the operation as a {@link java.time.Duration}.
+         *
+         * @return a Duration representing the elapsed time of the operation
+         */
+        default Duration getElapsedDuration() {
+            return Duration.ofNanos(getElapsedNanos());
+        }
     }
 
     /**
@@ -72,7 +83,7 @@ public class Timing {
          */
         @KiwiDeprecated(
                 removeAt = "4.0.0",
-                replacedBy = "TimedNotResult#ofElapsedMillis"
+                replacedBy = "TimedNoResult#ofElapsedMillis"
         )
         @Deprecated(since = "3.0.0", forRemoval = true)
         @SuppressWarnings({"java:S1133", "DeprecatedIsStillUsed"})
@@ -135,7 +146,7 @@ public class Timing {
          */
         @KiwiDeprecated(
                 removeAt = "4.0.0",
-                replacedBy = "TimedNotResult#ofElapsedMillis"
+                replacedBy = "TimedNoResult#ofElapsedMillis"
         )
         @Deprecated(since = "3.0.0", forRemoval = true)
         @SuppressWarnings({"java:S1133", "DeprecatedIsStillUsed"})
@@ -274,6 +285,15 @@ public class Timing {
         }
 
         /**
+         * Returns the elapsed time of the operation as a {@link java.time.Duration}.
+         *
+         * @return a Duration representing the elapsed time of the operation
+         */
+        default Duration getElapsedDuration() {
+            return Duration.ofNanos(getElapsedNanos());
+        }
+
+        /**
          * @return true if the operation completed without exception, otherwise false
          */
         default boolean operationSucceeded() {
@@ -288,8 +308,43 @@ public class Timing {
         }
 
         /**
-         * @return an Optional that will contain a RuntimeException if the operation failed.
-         * If called when the operation succeeded, an empty Optional is always returned.
+         * Returns the exception if the operation failed, or null if it succeeded.
+         * <p>
+         * Note: a null return value does not distinguish between "the operation
+         * succeeded" and "no exception was thrown" — use {@link #hasException()}
+         * or {@link #operationSucceeded()} for explicit checks.
+         *
+         * @return the exception thrown by the operation, or null if the operation succeeded
+         */
+        @Nullable
+        default RuntimeException getExceptionOrNull() {
+            return getException().orElse(null);
+        }
+
+        /**
+         * Returns the exception, assuming the operation failed.
+         * <p>
+         * This is intended for use after an explicit check, for example:
+         * <pre>{@code
+         * if (timed.hasException()) {
+         *     throw timed.getRequiredException();
+         * }
+         * }</pre>
+         *
+         * @return the exception thrown by the operation
+         * @throws IllegalStateException if the operation succeeded and no exception is present
+         */
+        default RuntimeException getRequiredException() {
+            return getException().orElseThrow(() ->
+                    new IllegalStateException("Operation succeeded; no exception is present"));
+        }
+
+        /**
+         * Returns an Optional containing the exception if the operation failed.
+         * If the operation succeeds, an empty Optional is always returned.
+         *
+         * @return an Optional containing the RuntimeException if the operation failed,
+         * otherwise an empty Optional
          */
         Optional<RuntimeException> getException();
     }
@@ -350,6 +405,8 @@ public class Timing {
         }
 
         /**
+         * Returns true if the operation succeeded, regardless of whether the result is null.
+         *
          * @return true if the operation succeeded and contains a (possibly null) result
          */
         public boolean hasResult() {
@@ -357,8 +414,83 @@ public class Timing {
         }
 
         /**
-         * @return an Optional that will contain a (possibly null) result when the operation succeeds.
-         * If called when the operation failed, an empty Optional is always returned.
+         * Returns the result if the operation succeeded, or null if it failed.
+         * <p>
+         * A null return value is ambiguous: it may mean the operation failed,
+         * or it may mean the operation succeeded with a null result. Use
+         * {@link #hasResult()} or {@link #isNullResult()} to distinguish these cases
+         * when the difference matters.
+         *
+         * @return the result of the operation, or null if the operation failed
+         */
+        @Nullable
+        public R getResultOrNull() {
+            return hasResult() ? result : null;
+        }
+
+        /**
+         * Returns the result, assuming the operation succeeded.
+         * <p>
+         * This is intended for use after an explicit check, for example:
+         * <pre>{@code
+         * if (timed.hasResult()) {
+         *     process(timed.getRequiredResult());
+         * }
+         * }</pre>
+         * Note: a null return value is valid when the operation succeeded with a
+         * null result. Use {@link #isNullResult()} if you need to distinguish a
+         * null result from a failed operation.
+         *
+         * @return the result of the operation, which may be null if the operation
+         * succeeded with a null result
+         * @throws IllegalStateException if the operation failed (i.e., threw an exception)
+         */
+        public R getRequiredResult() {
+            if (hasResult()) {
+                return result;
+            }
+
+            throw new IllegalStateException("Operation failed; no result is present");
+        }
+
+        /**
+         * Returns the result if the operation succeeded, otherwise re-throws the
+         * exception that the operation threw.
+         * <p>
+         * This provides a convenient one-liner for callers that want to propagate
+         * the original failure without an explicit check:
+         * <pre>{@code
+         * var value = timed.getResultOrThrow();
+         * }</pre>
+         * Unlike {@link #getRequiredResult()}, this does not throw an
+         * {@link IllegalStateException} — it propagates the original
+         * {@link RuntimeException} as-is.
+         * <p>
+         * Note: a null return value is valid when the operation succeeded with a
+         * null result. Use {@link #isNullResult()} if you need to distinguish a
+         * null result from a failed operation.
+         *
+         * @return the result of the operation, which may be null if the operation
+         * succeeded with a null result
+         * @throws RuntimeException the original exception thrown by the operation,
+         *                          if the operation failed
+         */
+        @Nullable
+        public R getResultOrThrow() {
+            if (hasResult()) {
+                return result;
+            }
+
+            throw exception;
+        }
+
+        /**
+         * Returns an Optional containing the result if the operation succeeded.
+         * If the operation succeeds with a null result, an empty Optional is returned.
+         * If the operation failed, an empty Optional is always returned.
+         *
+         * @return an Optional containing the result if the operation succeeded,
+         * otherwise an empty Optional
          */
         public Optional<R> getResult() {
             return Optional.ofNullable(result);

--- a/src/test/java/org/kiwiproject/beta/time/TimingTest.java
+++ b/src/test/java/org/kiwiproject/beta/time/TimingTest.java
@@ -2,6 +2,7 @@ package org.kiwiproject.beta.time;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -20,6 +21,7 @@ import org.kiwiproject.beta.time.Timing.TimedWithResult;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.time.Duration;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
@@ -111,7 +113,8 @@ class TimingTest {
             assertAll(
                     () -> assertThat(result.getResult()).isEqualTo("the result"),
                     () -> assertThat(result.getElapsedMillis()).isEqualTo(millis),
-                    () -> assertThat(result.getElapsedNanos()).isEqualTo(TimeUnit.MILLISECONDS.toNanos(millis))
+                    () -> assertThat(result.getElapsedNanos()).isEqualTo(TimeUnit.MILLISECONDS.toNanos(millis)),
+                    () -> assertThat(result.getElapsedDuration()).isEqualTo(Duration.ofNanos(result.getElapsedNanos()))
             );
         }
 
@@ -124,7 +127,8 @@ class TimingTest {
             assertAll(
                     () -> assertThat(result.getResult()).isEqualTo("the result"),
                     () -> assertThat(result.getElapsedMillis()).isEqualTo(millis),
-                    () -> assertThat(result.getElapsedNanos()).isEqualTo(TimeUnit.MILLISECONDS.toNanos(millis))
+                    () -> assertThat(result.getElapsedNanos()).isEqualTo(TimeUnit.MILLISECONDS.toNanos(millis)),
+                    () -> assertThat(result.getElapsedDuration()).isEqualTo(Duration.ofNanos(result.getElapsedNanos()))
             );
         }
 
@@ -146,7 +150,8 @@ class TimingTest {
 
             assertAll(
                     () -> assertThat(result.getElapsedMillis()).isEqualTo(millis),
-                    () -> assertThat(result.getElapsedNanos()).isEqualTo(TimeUnit.MILLISECONDS.toNanos(millis))
+                    () -> assertThat(result.getElapsedNanos()).isEqualTo(TimeUnit.MILLISECONDS.toNanos(millis)),
+                    () -> assertThat(result.getElapsedDuration()).isEqualTo(Duration.ofNanos(result.getElapsedNanos()))
             );
         }
 
@@ -158,7 +163,8 @@ class TimingTest {
 
             assertAll(
                     () -> assertThat(result.getElapsedMillis()).isEqualTo(millis),
-                    () -> assertThat(result.getElapsedNanos()).isEqualTo(TimeUnit.MILLISECONDS.toNanos(millis))
+                    () -> assertThat(result.getElapsedNanos()).isEqualTo(TimeUnit.MILLISECONDS.toNanos(millis)),
+                    () -> assertThat(result.getElapsedDuration()).isEqualTo(Duration.ofNanos(result.getElapsedNanos()))
             );
         }
 
@@ -192,14 +198,22 @@ class TimingTest {
             var result = new TimedWithErrorOrResult<>(42_000_000L, "the result", null);
 
             assertAll(
-                () -> assertThat(result.getElapsedNanos()).isEqualTo(42_000_000L),
-                () -> assertThat(result.getElapsedMillis()).isEqualTo(42L),
-                () -> assertThat(result.operationSucceeded()).isTrue(),
-                () -> assertThat(result.hasResult()).isTrue(),
-                () -> assertThat(result.isNullResult()).isFalse(),
-                () -> assertThat(result.getResult()).contains("the result"),
-                () -> assertThat(result.hasException()).isFalse(),
-                () -> assertThat(result.getException()).isEmpty()
+                    () -> assertThat(result.getElapsedNanos()).isEqualTo(42_000_000L),
+                    () -> assertThat(result.getElapsedMillis()).isEqualTo(42L),
+                    () -> assertThat(result.getElapsedDuration()).isEqualTo(Duration.ofNanos(result.getElapsedNanos())),
+                    () -> assertThat(result.operationSucceeded()).isTrue(),
+                    () -> assertThat(result.hasResult()).isTrue(),
+                    () -> assertThat(result.isNullResult()).isFalse(),
+                    () -> assertThat(result.getResult()).contains("the result"),
+                    () -> assertThat(result.hasException()).isFalse(),
+                    () -> assertThat(result.getException()).isEmpty(),
+                    () -> assertThat(result.getResultOrNull()).isEqualTo("the result"),
+                    () -> assertThat(result.getRequiredResult()).isEqualTo("the result"),
+                    () -> assertThat(result.getResultOrThrow()).isEqualTo("the result"),
+                    () -> assertThat(result.getExceptionOrNull()).isNull(),
+                    () -> assertThatIllegalStateException()
+                            .isThrownBy(result::getRequiredException)
+                            .withMessage("Operation succeeded; no exception is present")
             );
         }
 
@@ -208,14 +222,22 @@ class TimingTest {
             var result = new TimedWithErrorOrResult<>(420_000_000L, null, null);
 
             assertAll(
-                () -> assertThat(result.getElapsedNanos()).isEqualTo(420_000_000L),
-                () -> assertThat(result.getElapsedMillis()).isEqualTo(420L),
-                () -> assertThat(result.operationSucceeded()).isTrue(),
-                () -> assertThat(result.hasResult()).isTrue(),
-                () -> assertThat(result.isNullResult()).isTrue(),
-                () -> assertThat(result.getResult()).isEmpty(),
-                () -> assertThat(result.hasException()).isFalse(),
-                () -> assertThat(result.getException()).isEmpty()
+                    () -> assertThat(result.getElapsedNanos()).isEqualTo(420_000_000L),
+                    () -> assertThat(result.getElapsedMillis()).isEqualTo(420L),
+                    () -> assertThat(result.getElapsedDuration()).isEqualTo(Duration.ofNanos(result.getElapsedNanos())),
+                    () -> assertThat(result.operationSucceeded()).isTrue(),
+                    () -> assertThat(result.hasResult()).isTrue(),
+                    () -> assertThat(result.isNullResult()).isTrue(),
+                    () -> assertThat(result.getResult()).isEmpty(),
+                    () -> assertThat(result.hasException()).isFalse(),
+                    () -> assertThat(result.getException()).isEmpty(),
+                    () -> assertThat(result.getResultOrNull()).isNull(),
+                    () -> assertThat(result.getRequiredResult()).isNull(),
+                    () -> assertThat(result.getResultOrThrow()).isNull(),
+                    () -> assertThat(result.getExceptionOrNull()).isNull(),
+                    () -> assertThatIllegalStateException()
+                            .isThrownBy(result::getRequiredException)
+                            .withMessage("Operation succeeded; no exception is present")
             );
         }
 
@@ -225,13 +247,21 @@ class TimingTest {
             var result = new TimedWithErrorOrResult<>(126_000_000L, null, error);
 
             assertAll(
-                () -> assertThat(result.getElapsedMillis()).isEqualTo(126L),
-                () -> assertThat(result.operationSucceeded()).isFalse(),
-                () -> assertThat(result.hasResult()).isFalse(),
-                () -> assertThat(result.isNullResult()).isFalse(),
-                () -> assertThat(result.getResult()).isEmpty(),
-                () -> assertThat(result.hasException()).isTrue(),
-                () -> assertThat(result.getException()).contains(error)
+                    () -> assertThat(result.getElapsedMillis()).isEqualTo(126L),
+                    () -> assertThat(result.getElapsedDuration()).isEqualTo(Duration.ofNanos(result.getElapsedNanos())),
+                    () -> assertThat(result.operationSucceeded()).isFalse(),
+                    () -> assertThat(result.hasResult()).isFalse(),
+                    () -> assertThat(result.isNullResult()).isFalse(),
+                    () -> assertThat(result.getResult()).isEmpty(),
+                    () -> assertThat(result.hasException()).isTrue(),
+                    () -> assertThat(result.getException()).contains(error),
+                    () -> assertThat(result.getResultOrNull()).isNull(),
+                    () -> assertThatIllegalStateException()
+                            .isThrownBy(result::getRequiredResult)
+                            .withMessage("Operation failed; no result is present"),
+                    () -> assertThatThrownBy(result::getResultOrThrow).isSameAs(error),
+                    () -> assertThat(result.getExceptionOrNull()).isSameAs(error),
+                    () -> assertThat(result.getRequiredException()).isSameAs(error)
             );
         }
     }
@@ -244,11 +274,16 @@ class TimingTest {
             var result = TimedWithErrorNoResult.ofSuccess(42_000_000L);
 
             assertAll(
-                () -> assertThat(result.getElapsedNanos()).isEqualTo(42_000_000L),
-                () -> assertThat(result.getElapsedMillis()).isEqualTo(42L),
-                () -> assertThat(result.operationSucceeded()).isTrue(),
-                () -> assertThat(result.hasException()).isFalse(),
-                () -> assertThat(result.getException()).isEmpty()
+                    () -> assertThat(result.getElapsedNanos()).isEqualTo(42_000_000L),
+                    () -> assertThat(result.getElapsedMillis()).isEqualTo(42L),
+                    () -> assertThat(result.getElapsedDuration()).isEqualTo(Duration.ofNanos(result.getElapsedNanos())),
+                    () -> assertThat(result.operationSucceeded()).isTrue(),
+                    () -> assertThat(result.hasException()).isFalse(),
+                    () -> assertThat(result.getException()).isEmpty(),
+                    () -> assertThat(result.getExceptionOrNull()).isNull(),
+                    () -> assertThatIllegalStateException()
+                            .isThrownBy(result::getRequiredException)
+                            .withMessage("Operation succeeded; no exception is present")
             );
         }
 
@@ -258,11 +293,14 @@ class TimingTest {
             var result = TimedWithErrorNoResult.ofException(420_000_000L, error);
 
             assertAll(
-                () -> assertThat(result.getElapsedNanos()).isEqualTo(420_000_000L),
-                () -> assertThat(result.getElapsedMillis()).isEqualTo(420L),
-                () -> assertThat(result.operationSucceeded()).isFalse(),
-                () -> assertThat(result.hasException()).isTrue(),
-                () -> assertThat(result.getException()).contains(error)
+                    () -> assertThat(result.getElapsedNanos()).isEqualTo(420_000_000L),
+                    () -> assertThat(result.getElapsedMillis()).isEqualTo(420L),
+                    () -> assertThat(result.getElapsedDuration()).isEqualTo(Duration.ofNanos(result.getElapsedNanos())),
+                    () -> assertThat(result.operationSucceeded()).isFalse(),
+                    () -> assertThat(result.hasException()).isTrue(),
+                    () -> assertThat(result.getException()).contains(error),
+                    () -> assertThat(result.getExceptionOrNull()).isSameAs(error),
+                    () -> assertThat(result.getRequiredException()).isSameAs(error)
             );
         }
 


### PR DESCRIPTION
Add new accessor methods to TimedWithError, TimedWithErrorOrResult, and TimedWithErrorNoResult to improve ergonomics and reduce boilerplate when inspecting timed operation results.

- Add getExceptionOrNull() and getRequiredException() as default methods on TimedWithError
- Add getResultOrNull(), getRequiredResult(), and getResultOrThrow() to TimedWithErrorOrResult
- Add getElapsedDuration() as a default method on both Timed and TimedWithError
- Fix incorrect Javadoc on TimedWithErrorOrResult#getResult() re: Optional and null

Closes #524