### PR TITLE
fix: replace usage of deprecated KiwiSl44j#log methods

### DIFF
--- a/src/main/java/org/kiwiproject/beta/base/KiwiCloseables.java
+++ b/src/main/java/org/kiwiproject/beta/base/KiwiCloseables.java
@@ -16,7 +16,6 @@ import lombok.experimental.Accessors;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.Nullable;
-import org.kiwiproject.beta.slf4j.KiwiSlf4j;
 import org.slf4j.event.Level;
 
 import java.io.Closeable;
@@ -303,7 +302,7 @@ public class KiwiCloseables {
     }
 
     private static void logExceptionClosingObject(Level level, Object object, String methodName, Exception exception) {
-        KiwiSlf4j.log(LOG, level, "Suppressed exception thrown while closing {} from method {}",
+        LOG.atLevel(level).log("Suppressed exception thrown while closing {} from method {}",
                 object.getClass().getName(), methodName, exception);
     }
 
@@ -328,7 +327,7 @@ public class KiwiCloseables {
     }
 
     private static void logExceptionClosingClosable(Level level, Closeable closeable, Exception exception) {
-        KiwiSlf4j.log(LOG, level, "Suppressed exception thrown while closing Closeable ({})",
+        LOG.atLevel(level).log("Suppressed exception thrown while closing Closeable ({})",
                 closeable.getClass().getName(), exception);
     }
 

--- a/src/main/java/org/kiwiproject/beta/slf4j/TimestampingLogger.java
+++ b/src/main/java/org/kiwiproject/beta/slf4j/TimestampingLogger.java
@@ -187,7 +187,7 @@ public class TimestampingLogger {
     public void logElapsed(Level level, String message, Object... args) {
         if (KiwiSlf4j.isEnabled(logger, level)) {
             var now = System.nanoTime();
-            KiwiSlf4j.log(logger, level, message, args);
+            logger.atLevel(level).log(message, args);
             logElapsedSincePreviousTimestamp(level, now);
             previousTimestamp = now;
             ++logCount;
@@ -198,9 +198,9 @@ public class TimestampingLogger {
         if (previousTimestamp > 0) {
             var diffInNanos = now - previousTimestamp;
             var args = argumentTransformer.apply(diffInNanos, logCount);
-            KiwiSlf4j.log(logger, level, elapsedTimeTemplate, args);
+            logger.atLevel(level).log(elapsedTimeTemplate, args);
         } else if (isNotBlank(initialMessage)) {
-            KiwiSlf4j.log(logger, level, initialMessage);
+            logger.atLevel(level).log(initialMessage);
         }
     }
 
@@ -249,11 +249,11 @@ public class TimestampingLogger {
             var diffInNanos = now - previousTimestamp;
             var args = argumentTransformer.apply(diffInNanos, logCount);
             var elapsedTimeMessage = KiwiStrings.f(elapsedTimeTemplate, args);
-            KiwiSlf4j.log(logger, level, formattedMessage + " " + elapsedTimeMessage);
+            logger.atLevel(level).log(formattedMessage + " " + elapsedTimeMessage);
         } else if (isBlank(initialMessage)) {
-            KiwiSlf4j.log(logger, level, formattedMessage);
+            logger.atLevel(level).log(formattedMessage);
         } else {
-            KiwiSlf4j.log(logger, level, formattedMessage + " " + initialMessage);
+            logger.atLevel(level).log(formattedMessage + " " + initialMessage);
         }
     }
 }


### PR DESCRIPTION
Replace usage of the (now-deprecated) KiwiSlf4j#log methods in TimestampingLogger and KiwiCloseables.

Related to #613