### PR TITLE
Remove redundant sonar.host.url from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,6 @@
         <!--  Sonar properties -->
         <sonar.projectKey>sleberknight_kiwi-beta</sonar.projectKey>
         <sonar.organization>sleberknight</sonar.organization>
-        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.sources>src/main/java,src/main/kotlin</sonar.sources>
         <sonar.tests>src/test/java,src/test/kotlin</sonar.tests>
     </properties>


### PR DESCRIPTION
Remove the redundant sonar.host.url property from pom.xml. It is already defined in kiwi-parent and does not need to be redefined here.