### PR TITLE
chore: exclude org.kiwiproject from Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,8 @@ updates:
       semver-patch-days: 5
       semver-minor-days: 14
       semver-major-days: 30
+      exclude:
+        - "org.kiwiproject:*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Exclude org.kiwiproject dependencies from the Dependabot cooldown period so that kiwiproject library updates are not delayed.

This mirrors the same change already made in kiwiproject-changelog.